### PR TITLE
Add frontend unit tests for API, auth, and UI components

### DIFF
--- a/src/frontend/package-lock.json
+++ b/src/frontend/package-lock.json
@@ -15,16 +15,68 @@
       "devDependencies": {
         "@eslint/js": "^9.39.4",
         "@playwright/test": "^1.59.1",
+        "@testing-library/jest-dom": "^6.9.1",
+        "@testing-library/react": "^16.3.2",
+        "@testing-library/user-event": "^14.6.1",
         "@types/react": "^19.2.14",
         "@types/react-dom": "^19.2.3",
         "@vitejs/plugin-react": "^6.0.0",
+        "@vitest/ui": "^4.1.4",
         "dotenv": "^17.4.0",
         "eslint": "^9.39.4",
         "eslint-plugin-react-hooks": "^7.0.1",
         "eslint-plugin-react-refresh": "^0.5.2",
         "globals": "^17.4.0",
-        "vite": "^8.0.0"
+        "jsdom": "^29.0.2",
+        "vite": "^8.0.0",
+        "vitest": "^4.1.4"
       }
+    },
+    "node_modules/@adobe/css-tools": {
+      "version": "4.4.4",
+      "resolved": "https://registry.npmjs.org/@adobe/css-tools/-/css-tools-4.4.4.tgz",
+      "integrity": "sha512-Elp+iwUx5rN5+Y8xLt5/GRoG20WGoDCQ/1Fb+1LiGtvwbDavuSk0jhD/eZdckHAuzcDzccnkv+rEjyWfRx18gg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@asamuzakjp/css-color": {
+      "version": "5.1.9",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-5.1.9.tgz",
+      "integrity": "sha512-zd9c/Wdso6v1U7v6w3i/hbAr4K7NaSHImdpvmLt+Y9ea5BhilnIGNkfhOJ7FEIuPipAnE9tZeDOll05WDT0kgg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/css-calc": "^3.1.1",
+        "@csstools/css-color-parser": "^4.0.2",
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@asamuzakjp/dom-selector": {
+      "version": "7.0.9",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/dom-selector/-/dom-selector-7.0.9.tgz",
+      "integrity": "sha512-r3ElRr7y8ucyN2KdICwGsmj19RoN13CLCa/pvGydghWK6ZzeKQ+TcDjVdtEZz2ElpndM5jXw//B9CEee0mWnVg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/nwsapi": "^2.3.9",
+        "bidi-js": "^1.0.3",
+        "css-tree": "^3.2.1",
+        "is-potential-custom-element-name": "^1.0.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@asamuzakjp/nwsapi": {
+      "version": "2.3.9",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/nwsapi/-/nwsapi-2.3.9.tgz",
+      "integrity": "sha512-n8GuYSrI9bF7FFZ/SjhwevlHc8xaVlb/7HmHelnc/PZXBD2ZR49NnN9sMMuDdEGPeeRQ5d0hqlSlEpgCX3Wl0Q==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@babel/code-frame": {
       "version": "7.29.0",
@@ -218,6 +270,16 @@
         "node": ">=6.0.0"
       }
     },
+    "node_modules/@babel/runtime": {
+      "version": "7.29.2",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.2.tgz",
+      "integrity": "sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
     "node_modules/@babel/template": {
       "version": "7.28.6",
       "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.28.6.tgz",
@@ -264,6 +326,159 @@
       },
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@bramus/specificity": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/@bramus/specificity/-/specificity-2.4.2.tgz",
+      "integrity": "sha512-ctxtJ/eA+t+6q2++vj5j7FYX3nRu311q1wfYH3xjlLOsczhlhxAg2FWNUXhpGvAw3BWo1xBcvOV6/YLc2r5FJw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "css-tree": "^3.0.0"
+      },
+      "bin": {
+        "specificity": "bin/cli.js"
+      }
+    },
+    "node_modules/@csstools/color-helpers": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-6.0.2.tgz",
+      "integrity": "sha512-LMGQLS9EuADloEFkcTBR3BwV/CGHV7zyDxVRtVDTwdI2Ca4it0CCVTT9wCkxSgokjE5Ho41hEPgb8OEUwoXr6Q==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "engines": {
+        "node": ">=20.19.0"
+      }
+    },
+    "node_modules/@csstools/css-calc": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-3.1.1.tgz",
+      "integrity": "sha512-HJ26Z/vmsZQqs/o3a6bgKslXGFAungXGbinULZO3eMsOyNJHeBBZfup5FiZInOghgoM4Hwnmw+OgbJCNg1wwUQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-color-parser": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-4.0.2.tgz",
+      "integrity": "sha512-0GEfbBLmTFf0dJlpsNU7zwxRIH0/BGEMuXLTCvFYxuL1tNhqzTbtnFICyJLTNK4a+RechKP75e7w42ClXSnJQw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/color-helpers": "^6.0.2",
+        "@csstools/css-calc": "^3.1.1"
+      },
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-parser-algorithms": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-4.0.0.tgz",
+      "integrity": "sha512-+B87qS7fIG3L5h3qwJ/IFbjoVoOe/bpOdh9hAjXbvx0o8ImEmUsGXN0inFOnk2ChCFgqkkGFQ+TpM5rbhkKe4w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-syntax-patches-for-csstree": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@csstools/css-syntax-patches-for-csstree/-/css-syntax-patches-for-csstree-1.1.2.tgz",
+      "integrity": "sha512-5GkLzz4prTIpoyeUiIu3iV6CSG3Plo7xRVOFPKI7FVEJ3mZ0A8SwK0XU3Gl7xAkiQ+mDyam+NNp875/C5y+jSA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "peerDependencies": {
+        "css-tree": "^3.2.1"
+      },
+      "peerDependenciesMeta": {
+        "css-tree": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@csstools/css-tokenizer": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-4.0.0.tgz",
+      "integrity": "sha512-QxULHAm7cNu72w97JUNCBFODFaXpbDg+dP8b/oWFAZ2MTRppA3U00Y2L1HqaS4J6yBqxwa/Y3nMBaxVKbB/NsA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
       }
     },
     "node_modules/@emnapi/core": {
@@ -457,6 +672,24 @@
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       }
     },
+    "node_modules/@exodus/bytes": {
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/@exodus/bytes/-/bytes-1.15.0.tgz",
+      "integrity": "sha512-UY0nlA+feH81UGSHv92sLEPLCeZFjXOuHhrIo0HQydScuQc8s0A7kL/UdgwgDq8g8ilksmuoF35YVTNphV2aBQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "@noble/hashes": "^1.8.0 || ^2.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@noble/hashes": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@humanfs/core": {
       "version": "0.19.1",
       "resolved": "https://registry.npmjs.org/@humanfs/core/-/core-0.19.1.tgz",
@@ -611,6 +844,13 @@
       "engines": {
         "node": ">=18"
       }
+    },
+    "node_modules/@polka/url": {
+      "version": "1.0.0-next.29",
+      "resolved": "https://registry.npmjs.org/@polka/url/-/url-1.0.0-next.29.tgz",
+      "integrity": "sha512-wwQAWhWSuHaag8c4q/KN/vCoeOJYshAIvMQwD4GpSb3OiZklFfvAgmj0VCBBImRpuF/aFgIRzllXlVX93Jevww==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@rolldown/binding-android-arm64": {
       "version": "1.0.0-rc.9",
@@ -874,6 +1114,103 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@testing-library/dom": {
+      "version": "10.4.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-10.4.1.tgz",
+      "integrity": "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@babel/code-frame": "^7.10.4",
+        "@babel/runtime": "^7.12.5",
+        "@types/aria-query": "^5.0.1",
+        "aria-query": "5.3.0",
+        "dom-accessibility-api": "^0.5.9",
+        "lz-string": "^1.5.0",
+        "picocolors": "1.1.1",
+        "pretty-format": "^27.0.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@testing-library/jest-dom": {
+      "version": "6.9.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/jest-dom/-/jest-dom-6.9.1.tgz",
+      "integrity": "sha512-zIcONa+hVtVSSep9UT3jZ5rizo2BsxgyDYU7WFD5eICBE7no3881HGeb/QkGfsJs6JTkY1aQhT7rIPC7e+0nnA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@adobe/css-tools": "^4.4.0",
+        "aria-query": "^5.0.0",
+        "css.escape": "^1.5.1",
+        "dom-accessibility-api": "^0.6.3",
+        "picocolors": "^1.1.1",
+        "redent": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=14",
+        "npm": ">=6",
+        "yarn": ">=1"
+      }
+    },
+    "node_modules/@testing-library/jest-dom/node_modules/dom-accessibility-api": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.6.3.tgz",
+      "integrity": "sha512-7ZgogeTnjuHbo+ct10G9Ffp0mif17idi0IyWNVA/wcwcm7NPOD/WEHVP3n7n3MhXqxoIYm8d6MuZohYWIZ4T3w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@testing-library/react": {
+      "version": "16.3.2",
+      "resolved": "https://registry.npmjs.org/@testing-library/react/-/react-16.3.2.tgz",
+      "integrity": "sha512-XU5/SytQM+ykqMnAnvB2umaJNIOsLF3PVv//1Ew4CTcpz0/BRyy/af40qqrt7SjKpDdT1saBMc42CUok5gaw+g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.12.5"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@testing-library/dom": "^10.0.0",
+        "@types/react": "^18.0.0 || ^19.0.0",
+        "@types/react-dom": "^18.0.0 || ^19.0.0",
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@testing-library/user-event": {
+      "version": "14.6.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/user-event/-/user-event-14.6.1.tgz",
+      "integrity": "sha512-vq7fv0rnt+QTXgPxr5Hjc210p6YKq2kmdziLgnsZGgLJ9e6VAShx1pACLuRjd/AS/sr7phAR58OIIpf0LlmQNw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12",
+        "npm": ">=6"
+      },
+      "peerDependencies": {
+        "@testing-library/dom": ">=7.21.4"
+      }
+    },
     "node_modules/@tybys/wasm-util": {
       "version": "0.10.1",
       "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.1.tgz",
@@ -884,6 +1221,32 @@
       "dependencies": {
         "tslib": "^2.4.0"
       }
+    },
+    "node_modules/@types/aria-query": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
+      "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
+      }
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/estree": {
       "version": "1.0.8",
@@ -945,6 +1308,141 @@
         }
       }
     },
+    "node_modules/@vitest/expect": {
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.4.tgz",
+      "integrity": "sha512-iPBpra+VDuXmBFI3FMKHSFXp3Gx5HfmSCE8X67Dn+bwephCnQCaB7qWK2ldHa+8ncN8hJU8VTMcxjPpyMkUjww==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.1.0",
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "4.1.4",
+        "@vitest/utils": "4.1.4",
+        "chai": "^6.2.2",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.4.tgz",
+      "integrity": "sha512-R9HTZBhW6yCSGbGQnDnH3QHfJxokKN4KB+Yvk9Q1le7eQNYwiCyKxmLmurSpFy6BzJanSLuEUDrD+j97Q+ZLPg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "4.1.4",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.21"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.4.tgz",
+      "integrity": "sha512-ddmDHU0gjEUyEVLxtZa7xamrpIefdEETu3nZjWtHeZX4QxqJ7tRxSteHVXJOcr8jhiLoGAhkK4WJ3WqBpjx42A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.4.tgz",
+      "integrity": "sha512-xTp7VZ5aXP5ZJrn15UtJUWlx6qXLnGtF6jNxHepdPHpMfz/aVPx+htHtgcAL2mDXJgKhpoo2e9/hVJsIeFbytQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "4.1.4",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.4.tgz",
+      "integrity": "sha512-MCjCFgaS8aZz+m5nTcEcgk/xhWv0rEH4Yl53PPlMXOZ1/Ka2VcZU6CJ+MgYCZbcJvzGhQRjVrGQNZqkGPttIKw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.4",
+        "@vitest/utils": "4.1.4",
+        "magic-string": "^0.30.21",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.4.tgz",
+      "integrity": "sha512-XxNdAsKW7C+FLydqFJLb5KhJtl3PGCMmYwFRfhvIgxJvLSXhhVI1zM8f1qD3Zg7RCjTSzDVyct6sghs9UEgBEQ==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/ui": {
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/@vitest/ui/-/ui-4.1.4.tgz",
+      "integrity": "sha512-EgFR7nlj5iTDYZYCvavjFokNYwr3c3ry0sFiCg+N7B233Nwp+NNx7eoF/XvMWDCKY71xXAG3kFkt97ZHBJVL8A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "4.1.4",
+        "fflate": "^0.8.2",
+        "flatted": "^3.4.2",
+        "pathe": "^2.0.3",
+        "sirv": "^3.0.2",
+        "tinyglobby": "^0.2.15",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "vitest": "4.1.4"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.4.tgz",
+      "integrity": "sha512-13QMT+eysM5uVGa1rG4kegGYNp6cnQcsTc67ELFbhNLQO+vgsygtYJx2khvdt4gVQqSSpC/KT5FZZxUpP3Oatw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.4",
+        "convert-source-map": "^2.0.0",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
     "node_modules/acorn": {
       "version": "8.16.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
@@ -985,6 +1483,17 @@
         "url": "https://github.com/sponsors/epoberezkin"
       }
     },
+    "node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/ansi-styles": {
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
@@ -1008,6 +1517,26 @@
       "dev": true,
       "license": "Python-2.0"
     },
+    "node_modules/aria-query": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.0.tgz",
+      "integrity": "sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "dequal": "^2.0.3"
+      }
+    },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/balanced-match": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
@@ -1026,6 +1555,16 @@
       },
       "engines": {
         "node": ">=6.0.0"
+      }
+    },
+    "node_modules/bidi-js": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/bidi-js/-/bidi-js-1.0.3.tgz",
+      "integrity": "sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "require-from-string": "^2.0.2"
       }
     },
     "node_modules/brace-expansion": {
@@ -1103,6 +1642,16 @@
         }
       ],
       "license": "CC-BY-4.0"
+    },
+    "node_modules/chai": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
+      "integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/chalk": {
       "version": "4.1.2",
@@ -1183,12 +1732,47 @@
         "node": ">= 8"
       }
     },
+    "node_modules/css-tree": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-3.2.1.tgz",
+      "integrity": "sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mdn-data": "2.27.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0"
+      }
+    },
+    "node_modules/css.escape": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/css.escape/-/css.escape-1.5.1.tgz",
+      "integrity": "sha512-YUifsXXuknHlUsmlgyY0PKzgPOr7/FjCePfHNt0jxm83wHZi44VDMQ7/fGNkjY3/jV1MC+1CmZbaHzugyeRtpg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/csstype": {
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/data-urls": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-7.0.0.tgz",
+      "integrity": "sha512-23XHcCF+coGYevirZceTVD7NdJOqVn+49IHyxgszm+JIiHLoB2TkmPtsYkNWT1pvRSGkc35L6NHs0yHkN2SumA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-mimetype": "^5.0.0",
+        "whatwg-url": "^16.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
     },
     "node_modules/debug": {
       "version": "4.4.3",
@@ -1208,12 +1792,29 @@
         }
       }
     },
+    "node_modules/decimal.js": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
+      "integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/deep-is": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
       "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/dequal": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
+      "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
     },
     "node_modules/detect-libc": {
       "version": "2.1.2",
@@ -1224,6 +1825,14 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/dom-accessibility-api": {
+      "version": "0.5.16",
+      "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
+      "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/dotenv": {
       "version": "17.4.0",
@@ -1244,6 +1853,26 @@
       "integrity": "sha512-QBMrTWEf00GXZmJyx2lbYD45jpI3TUFnNIzJ5BBc8piGUDwMPa1GV6HJWTZVvY/eiN3fSopl7NRbgGp9sZ9LTA==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/entities": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-6.0.1.tgz",
+      "integrity": "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/es-module-lexer": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.0.0.tgz",
+      "integrity": "sha512-5POEcUuZybH7IdmGsD8wlf0AI55wMecM9rVBTI/qEAy2c1kTOm3DjFYjrBdI2K3BaJjJYfYFeRtM0t9ssnRuxw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/escalade": {
       "version": "3.2.0",
@@ -1442,6 +2071,16 @@
         "node": ">=4.0"
       }
     },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
     "node_modules/esutils": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
@@ -1450,6 +2089,16 @@
       "license": "BSD-2-Clause",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
+      "integrity": "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
       }
     },
     "node_modules/fast-deep-equal": {
@@ -1490,6 +2139,13 @@
           "optional": true
         }
       }
+    },
+    "node_modules/fflate": {
+      "version": "0.8.2",
+      "resolved": "https://registry.npmjs.org/fflate/-/fflate-0.8.2.tgz",
+      "integrity": "sha512-cPJU47OaAoCbg0pBvzsgpTPhmhqI5eJjh/JIu8tPj5q+T7iLvW/JAYUqmE7KOB4R1ZyEhzBaIQpQpardBF5z8A==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/file-entry-cache": {
       "version": "8.0.0",
@@ -1536,9 +2192,9 @@
       }
     },
     "node_modules/flatted": {
-      "version": "3.4.1",
-      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.1.tgz",
-      "integrity": "sha512-IxfVbRFVlV8V/yRaGzk0UVIcsKKHMSfYw66T/u4nTwlWteQePsxe//LjudR1AMX4tZW3WFCh3Zqa/sjlqpbURQ==",
+      "version": "3.4.2",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.2.tgz",
+      "integrity": "sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==",
       "dev": true,
       "license": "ISC"
     },
@@ -1620,6 +2276,19 @@
         "hermes-estree": "0.25.1"
       }
     },
+    "node_modules/html-encoding-sniffer": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-6.0.0.tgz",
+      "integrity": "sha512-CV9TW3Y3f8/wT0BRFc1/KAVQ3TUHiXmaAb6VW9vtiMFf7SLoMd1PdAc4W3KFOFETBJUb90KatHqlsZMWV+R9Gg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@exodus/bytes": "^1.6.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
     "node_modules/ignore": {
       "version": "5.3.2",
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
@@ -1657,6 +2326,16 @@
         "node": ">=0.8.19"
       }
     },
+    "node_modules/indent-string": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-4.0.0.tgz",
+      "integrity": "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/is-extglob": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
@@ -1679,6 +2358,13 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/is-potential-custom-element-name": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
+      "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/isexe": {
       "version": "2.0.0",
@@ -1705,6 +2391,57 @@
       },
       "bin": {
         "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/jsdom": {
+      "version": "29.0.2",
+      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-29.0.2.tgz",
+      "integrity": "sha512-9VnGEBosc/ZpwyOsJBCQ/3I5p7Q5ngOY14a9bf5btenAORmZfDse1ZEheMiWcJ3h81+Fv7HmJFdS0szo/waF2w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/css-color": "^5.1.5",
+        "@asamuzakjp/dom-selector": "^7.0.6",
+        "@bramus/specificity": "^2.4.2",
+        "@csstools/css-syntax-patches-for-csstree": "^1.1.1",
+        "@exodus/bytes": "^1.15.0",
+        "css-tree": "^3.2.1",
+        "data-urls": "^7.0.0",
+        "decimal.js": "^10.6.0",
+        "html-encoding-sniffer": "^6.0.0",
+        "is-potential-custom-element-name": "^1.0.1",
+        "lru-cache": "^11.2.7",
+        "parse5": "^8.0.0",
+        "saxes": "^6.0.0",
+        "symbol-tree": "^3.2.4",
+        "tough-cookie": "^6.0.1",
+        "undici": "^7.24.5",
+        "w3c-xmlserializer": "^5.0.0",
+        "webidl-conversions": "^8.0.1",
+        "whatwg-mimetype": "^5.0.0",
+        "whatwg-url": "^16.0.1",
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "canvas": "^3.0.0"
+      },
+      "peerDependenciesMeta": {
+        "canvas": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/jsdom/node_modules/lru-cache": {
+      "version": "11.3.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.3.3.tgz",
+      "integrity": "sha512-JvNw9Y81y33E+BEYPr0U7omo+U9AySnsMsEiXgwT6yqd31VQWTLNQqmT4ou5eqPFUrTfIDFta2wKhB1hyohtAQ==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
       }
     },
     "node_modules/jsesc": {
@@ -2072,6 +2809,44 @@
         "yallist": "^3.0.2"
       }
     },
+    "node_modules/lz-string": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/lz-string/-/lz-string-1.5.0.tgz",
+      "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "bin": {
+        "lz-string": "bin/bin.js"
+      }
+    },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/mdn-data": {
+      "version": "2.27.1",
+      "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.27.1.tgz",
+      "integrity": "sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==",
+      "dev": true,
+      "license": "CC0-1.0"
+    },
+    "node_modules/min-indent": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/min-indent/-/min-indent-1.0.1.tgz",
+      "integrity": "sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/minimatch": {
       "version": "3.1.5",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
@@ -2083,6 +2858,16 @@
       },
       "engines": {
         "node": "*"
+      }
+    },
+    "node_modules/mrmime": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/mrmime/-/mrmime-2.0.1.tgz",
+      "integrity": "sha512-Y3wQdFg2Va6etvQ5I82yUhGdsKrcYox6p7FfL1LbK2J4V01F9TGlepTIhnK24t7koZibmg82KGglhA1XK5IsLQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/ms": {
@@ -2123,6 +2908,17 @@
       "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.36.tgz",
       "integrity": "sha512-TdC8FSgHz8Mwtw9g5L4gR/Sh9XhSP/0DEkQxfEFXOpiul5IiHgHan2VhYYb6agDSfp4KuvltmGApc8HMgUrIkA==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/obug": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.1.tgz",
+      "integrity": "sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==",
+      "dev": true,
+      "funding": [
+        "https://github.com/sponsors/sxzz",
+        "https://opencollective.com/debug"
+      ],
       "license": "MIT"
     },
     "node_modules/optionator": {
@@ -2188,6 +2984,19 @@
         "node": ">=6"
       }
     },
+    "node_modules/parse5": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-8.0.0.tgz",
+      "integrity": "sha512-9m4m5GSgXjL4AjumKzq1Fgfp3Z8rsvjRNbnkVwfu2ImRqE5D0LnY2QfDen18FSY9C573YU5XxSapdHZTZ2WolA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "entities": "^6.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
     "node_modules/path-exists": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
@@ -2207,6 +3016,13 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/picocolors": {
       "version": "1.1.1",
@@ -2314,6 +3130,36 @@
         "node": ">= 0.8.0"
       }
     },
+    "node_modules/pretty-format": {
+      "version": "27.5.1",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.5.1.tgz",
+      "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "ansi-regex": "^5.0.1",
+        "ansi-styles": "^5.0.0",
+        "react-is": "^17.0.1"
+      },
+      "engines": {
+        "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
+      }
+    },
+    "node_modules/pretty-format/node_modules/ansi-styles": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
     "node_modules/punycode": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
@@ -2344,6 +3190,14 @@
       "peerDependencies": {
         "react": "^19.2.4"
       }
+    },
+    "node_modules/react-is": {
+      "version": "17.0.2",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
+      "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/react-router": {
       "version": "7.13.2",
@@ -2381,6 +3235,30 @@
       "peerDependencies": {
         "react": ">=18",
         "react-dom": ">=18"
+      }
+    },
+    "node_modules/redent": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/redent/-/redent-3.0.0.tgz",
+      "integrity": "sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "indent-string": "^4.0.0",
+        "strip-indent": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/resolve-from": {
@@ -2434,6 +3312,19 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/saxes": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz",
+      "integrity": "sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "xmlchars": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=v12.22.7"
+      }
+    },
     "node_modules/scheduler": {
       "version": "0.27.0",
       "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.27.0.tgz",
@@ -2479,6 +3370,28 @@
         "node": ">=8"
       }
     },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/sirv": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/sirv/-/sirv-3.0.2.tgz",
+      "integrity": "sha512-2wcC/oGxHis/BoHkkPwldgiPSYcpZK3JU28WoMVv55yHJgcZ8rlXvuG9iZggz+sU1d4bRgIGASwyWqjxu3FM0g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@polka/url": "^1.0.0-next.24",
+        "mrmime": "^2.0.0",
+        "totalist": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/source-map-js": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
@@ -2487,6 +3400,33 @@
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/std-env": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.0.0.tgz",
+      "integrity": "sha512-zUMPtQ/HBY3/50VbpkupYHbRroTRZJPRLvreamgErJVys0ceuzMkD44J/QjqhHjOzK42GQ3QZIeFG1OYfOtKqQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/strip-indent": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-3.0.0.tgz",
+      "integrity": "sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "min-indent": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/strip-json-comments": {
@@ -2515,6 +3455,30 @@
         "node": ">=8"
       }
     },
+    "node_modules/symbol-tree": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
+      "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.1.1.tgz",
+      "integrity": "sha512-VKS/ZaQhhkKFMANmAOhhXVoIfBXblQxGX1myCQ2faQrfmobMftXeJPcZGp0gS07ocvGJWDLZGyOZDadDBqYIJg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/tinyglobby": {
       "version": "0.2.15",
       "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.15.tgz",
@@ -2530,6 +3494,72 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.1.0.tgz",
+      "integrity": "sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tldts": {
+      "version": "7.0.28",
+      "resolved": "https://registry.npmjs.org/tldts/-/tldts-7.0.28.tgz",
+      "integrity": "sha512-+Zg3vWhRUv8B1maGSTFdev9mjoo8Etn2Ayfs4cnjlD3CsGkxXX4QyW3j2WJ0wdjYcYmy7Lx2RDsZMhgCWafKIw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tldts-core": "^7.0.28"
+      },
+      "bin": {
+        "tldts": "bin/cli.js"
+      }
+    },
+    "node_modules/tldts-core": {
+      "version": "7.0.28",
+      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-7.0.28.tgz",
+      "integrity": "sha512-7W5Efjhsc3chVdFhqtaU0KtK32J37Zcr9RKtID54nG+tIpcY79CQK/veYPODxtD/LJ4Lue66jvrQzIX2Z2/pUQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/totalist": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/totalist/-/totalist-3.0.1.tgz",
+      "integrity": "sha512-sf4i37nQ2LBx4m3wB74y+ubopq6W/dIzXg0FDGjsYnZHVa1Da8FH853wlL2gtUhg+xJXjfk3kUZS3BRoQeoQBQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/tough-cookie": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-6.0.1.tgz",
+      "integrity": "sha512-LktZQb3IeoUWB9lqR5EWTHgW/VTITCXg4D21M+lvybRVdylLrRMnqaIONLVb5mav8vM19m44HIcGq4qASeu2Qw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "tldts": "^7.0.5"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/tr46": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-6.0.0.tgz",
+      "integrity": "sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "punycode": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=20"
       }
     },
     "node_modules/tslib": {
@@ -2551,6 +3581,16 @@
       },
       "engines": {
         "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/undici": {
+      "version": "7.24.7",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.24.7.tgz",
+      "integrity": "sha512-H/nlJ/h0ggGC+uRL3ovD+G0i4bqhvsDOpbDv7At5eFLlj2b41L8QliGbnl2H7SnDiYhENphh1tQFJZf+MyfLsQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.18.1"
       }
     },
     "node_modules/update-browserslist-db": {
@@ -2673,6 +3713,144 @@
         }
       }
     },
+    "node_modules/vitest": {
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.4.tgz",
+      "integrity": "sha512-tFuJqTxKb8AvfyqMfnavXdzfy3h3sWZRWwfluGbkeR7n0HUev+FmNgZ8SDrRBTVrVCjgH5cA21qGbCffMNtWvg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "4.1.4",
+        "@vitest/mocker": "4.1.4",
+        "@vitest/pretty-format": "4.1.4",
+        "@vitest/runner": "4.1.4",
+        "@vitest/snapshot": "4.1.4",
+        "@vitest/spy": "4.1.4",
+        "@vitest/utils": "4.1.4",
+        "es-module-lexer": "^2.0.0",
+        "expect-type": "^1.3.0",
+        "magic-string": "^0.30.21",
+        "obug": "^2.1.1",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.3",
+        "std-env": "^4.0.0-rc.1",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^1.0.2",
+        "tinyglobby": "^0.2.15",
+        "tinyrainbow": "^3.1.0",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@opentelemetry/api": "^1.9.0",
+        "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
+        "@vitest/browser-playwright": "4.1.4",
+        "@vitest/browser-preview": "4.1.4",
+        "@vitest/browser-webdriverio": "4.1.4",
+        "@vitest/coverage-istanbul": "4.1.4",
+        "@vitest/coverage-v8": "4.1.4",
+        "@vitest/ui": "4.1.4",
+        "happy-dom": "*",
+        "jsdom": "*",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser-playwright": {
+          "optional": true
+        },
+        "@vitest/browser-preview": {
+          "optional": true
+        },
+        "@vitest/browser-webdriverio": {
+          "optional": true
+        },
+        "@vitest/coverage-istanbul": {
+          "optional": true
+        },
+        "@vitest/coverage-v8": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        },
+        "vite": {
+          "optional": false
+        }
+      }
+    },
+    "node_modules/w3c-xmlserializer": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-5.0.0.tgz",
+      "integrity": "sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/webidl-conversions": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-8.0.1.tgz",
+      "integrity": "sha512-BMhLD/Sw+GbJC21C/UgyaZX41nPt8bUTg+jWyDeg7e7YN4xOM05YPSIXceACnXVtqyEw/LMClUQMtMZ+PGGpqQ==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/whatwg-mimetype": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-5.0.0.tgz",
+      "integrity": "sha512-sXcNcHOC51uPGF0P/D4NVtrkjSU2fNsm9iog4ZvZJsL3rjoDAzXZhkm2MWt1y+PUdggKAYVoMAIYcs78wJ51Cw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/whatwg-url": {
+      "version": "16.0.1",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-16.0.1.tgz",
+      "integrity": "sha512-1to4zXBxmXHV3IiSSEInrreIlu02vUOvrhxJJH5vcxYTBDAx51cqZiKdyTxlecdKNSjj8EcxGBxNf6Vg+945gw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@exodus/bytes": "^1.11.0",
+        "tr46": "^6.0.0",
+        "webidl-conversions": "^8.0.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
     "node_modules/which": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
@@ -2689,6 +3867,23 @@
         "node": ">= 8"
       }
     },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/word-wrap": {
       "version": "1.2.5",
       "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.5.tgz",
@@ -2698,6 +3893,23 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/xml-name-validator": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-5.0.0.tgz",
+      "integrity": "sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/xmlchars": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
+      "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/yallist": {
       "version": "3.1.1",

--- a/src/frontend/package.json
+++ b/src/frontend/package.json
@@ -8,6 +8,8 @@
     "build": "vite build",
     "lint": "eslint .",
     "preview": "vite preview",
+    "test": "vitest",
+    "test:ui": "vitest --ui",
     "test:e2e": "playwright test",
     "test:e2e:reuse-dev": "PW_SKIP_WEBSERVER=1 playwright test",
     "test:e2e:ui": "playwright test --ui",
@@ -21,14 +23,20 @@
   "devDependencies": {
     "@eslint/js": "^9.39.4",
     "@playwright/test": "^1.59.1",
+    "@testing-library/jest-dom": "^6.9.1",
+    "@testing-library/react": "^16.3.2",
+    "@testing-library/user-event": "^14.6.1",
     "@types/react": "^19.2.14",
     "@types/react-dom": "^19.2.3",
     "@vitejs/plugin-react": "^6.0.0",
+    "@vitest/ui": "^4.1.4",
     "dotenv": "^17.4.0",
     "eslint": "^9.39.4",
     "eslint-plugin-react-hooks": "^7.0.1",
     "eslint-plugin-react-refresh": "^0.5.2",
     "globals": "^17.4.0",
-    "vite": "^8.0.0"
+    "jsdom": "^29.0.2",
+    "vite": "^8.0.0",
+    "vitest": "^4.1.4"
   }
 }

--- a/src/frontend/src/api/eventsApi.test.js
+++ b/src/frontend/src/api/eventsApi.test.js
@@ -1,0 +1,150 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { fetchEvents, createEvent, updateEvent, cancelEvent } from './eventsApi'
+
+vi.mock('../auth/authStorage', () => ({
+  getStoredAuthSession: vi.fn(),
+}))
+
+import { getStoredAuthSession } from '../auth/authStorage'
+
+function mockFetch(status, body) {
+  return vi.fn().mockResolvedValue({
+    ok: status >= 200 && status < 300,
+    status,
+    json: () => Promise.resolve(body),
+  })
+}
+
+beforeEach(() => {
+  vi.resetAllMocks()
+  getStoredAuthSession.mockReturnValue(null)
+})
+
+describe('fetchEvents', () => {
+  it('returns parsed JSON on success', async () => {
+    global.fetch = mockFetch(200, [{ id: 1 }])
+    expect(await fetchEvents()).toEqual([{ id: 1 }])
+  })
+
+  it('throws with the server message on failure', async () => {
+    global.fetch = mockFetch(500, { message: 'Server error' })
+    await expect(fetchEvents()).rejects.toThrow('Server error')
+  })
+
+  it('thrown error has the response status', async () => {
+    global.fetch = mockFetch(500, { message: 'oops' })
+    const err = await fetchEvents().catch(e => e)
+    expect(err.status).toBe(500)
+  })
+
+  it('includes Authorization header when a session exists', async () => {
+    getStoredAuthSession.mockReturnValue({ token: 'mytoken' })
+    global.fetch = mockFetch(200, [])
+    await fetchEvents()
+    const [, options] = global.fetch.mock.calls[0]
+    expect(options.headers.Authorization).toBe('Bearer mytoken')
+  })
+
+  it('omits Authorization header when no session', async () => {
+    global.fetch = mockFetch(200, [])
+    await fetchEvents()
+    const [, options] = global.fetch.mock.calls[0]
+    expect(options.headers.Authorization).toBeUndefined()
+  })
+
+  it('calls the correct URL', async () => {
+    global.fetch = mockFetch(200, [])
+    await fetchEvents()
+    const [url] = global.fetch.mock.calls[0]
+    expect(url).toBe('/api/events')
+  })
+})
+
+describe('createEvent', () => {
+  const payload = { title: 'Test', category: 'MOVIE' }
+
+  it('returns parsed JSON on success', async () => {
+    global.fetch = mockFetch(200, { id: 1 })
+    expect(await createEvent(payload)).toEqual({ id: 1 })
+  })
+
+  it('uses POST method', async () => {
+    global.fetch = mockFetch(200, { id: 1 })
+    await createEvent(payload)
+    const [, options] = global.fetch.mock.calls[0]
+    expect(options.method).toBe('POST')
+  })
+
+  it('serializes the payload as JSON', async () => {
+    global.fetch = mockFetch(200, { id: 1 })
+    await createEvent(payload)
+    const [, options] = global.fetch.mock.calls[0]
+    expect(options.body).toBe(JSON.stringify(payload))
+  })
+
+  it('sends Content-Type header', async () => {
+    global.fetch = mockFetch(200, { id: 1 })
+    await createEvent(payload)
+    const [, options] = global.fetch.mock.calls[0]
+    expect(options.headers['Content-Type']).toBe('application/json')
+  })
+
+  it('throws with the server message on failure', async () => {
+    global.fetch = mockFetch(400, { message: 'Bad request' })
+    await expect(createEvent(payload)).rejects.toThrow('Bad request')
+  })
+})
+
+describe('updateEvent', () => {
+  const payload = { title: 'Updated' }
+
+  it('returns parsed JSON on success', async () => {
+    global.fetch = mockFetch(200, { id: 5 })
+    expect(await updateEvent(5, payload)).toEqual({ id: 5 })
+  })
+
+  it('uses PUT method', async () => {
+    global.fetch = mockFetch(200, { id: 5 })
+    await updateEvent(5, payload)
+    const [, options] = global.fetch.mock.calls[0]
+    expect(options.method).toBe('PUT')
+  })
+
+  it('calls the correct URL with the event id', async () => {
+    global.fetch = mockFetch(200, { id: 5 })
+    await updateEvent(5, payload)
+    const [url] = global.fetch.mock.calls[0]
+    expect(url).toBe('/api/events/5')
+  })
+
+  it('throws with the server message on failure', async () => {
+    global.fetch = mockFetch(404, { message: 'Not found' })
+    await expect(updateEvent(99, payload)).rejects.toThrow('Not found')
+  })
+})
+
+describe('cancelEvent', () => {
+  it('returns parsed JSON on success', async () => {
+    global.fetch = mockFetch(200, { id: 3, isCancelled: true })
+    expect(await cancelEvent(3)).toEqual({ id: 3, isCancelled: true })
+  })
+
+  it('uses PATCH method', async () => {
+    global.fetch = mockFetch(200, {})
+    await cancelEvent(3)
+    const [, options] = global.fetch.mock.calls[0]
+    expect(options.method).toBe('PATCH')
+  })
+
+  it('calls the correct cancel URL', async () => {
+    global.fetch = mockFetch(200, {})
+    await cancelEvent(3)
+    const [url] = global.fetch.mock.calls[0]
+    expect(url).toBe('/api/events/3/cancel')
+  })
+
+  it('throws with the server message on failure', async () => {
+    global.fetch = mockFetch(403, { message: 'Forbidden' })
+    await expect(cancelEvent(3)).rejects.toThrow('Forbidden')
+  })
+})

--- a/src/frontend/src/api/reservationsApi.test.js
+++ b/src/frontend/src/api/reservationsApi.test.js
@@ -1,0 +1,144 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import {
+  fetchReservations,
+  fetchReservationsByUser,
+  fetchReservationsByEvent,
+  createReservation,
+  cancelReservation,
+} from './reservationsApi'
+
+vi.mock('../auth/authStorage', () => ({
+  getStoredAuthSession: vi.fn(),
+}))
+
+import { getStoredAuthSession } from '../auth/authStorage'
+
+function mockFetch(status, body) {
+  return vi.fn().mockResolvedValue({
+    ok: status >= 200 && status < 300,
+    status,
+    json: () => Promise.resolve(body),
+  })
+}
+
+beforeEach(() => {
+  vi.resetAllMocks()
+  getStoredAuthSession.mockReturnValue(null)
+})
+
+describe('fetchReservations', () => {
+  it('returns parsed JSON on success', async () => {
+    global.fetch = mockFetch(200, [{ id: 1 }])
+    expect(await fetchReservations()).toEqual([{ id: 1 }])
+  })
+
+  it('throws with the server message on failure', async () => {
+    global.fetch = mockFetch(401, { message: 'Unauthorized' })
+    await expect(fetchReservations()).rejects.toThrow('Unauthorized')
+  })
+
+  it('thrown error has the response status', async () => {
+    global.fetch = mockFetch(401, { message: 'Unauthorized' })
+    const err = await fetchReservations().catch(e => e)
+    expect(err.status).toBe(401)
+  })
+
+  it('calls the correct URL', async () => {
+    global.fetch = mockFetch(200, [])
+    await fetchReservations()
+    const [url] = global.fetch.mock.calls[0]
+    expect(url).toBe('/api/reservations')
+  })
+})
+
+describe('fetchReservationsByUser', () => {
+  it('calls the correct URL with the user id', async () => {
+    global.fetch = mockFetch(200, [])
+    await fetchReservationsByUser(42)
+    const [url] = global.fetch.mock.calls[0]
+    expect(url).toBe('/api/reservations/user/42')
+  })
+
+  it('returns parsed JSON on success', async () => {
+    global.fetch = mockFetch(200, [{ id: 1, userId: 42 }])
+    expect(await fetchReservationsByUser(42)).toEqual([{ id: 1, userId: 42 }])
+  })
+
+  it('throws with the server message on failure', async () => {
+    global.fetch = mockFetch(500, { message: 'Server error' })
+    await expect(fetchReservationsByUser(1)).rejects.toThrow('Server error')
+  })
+})
+
+describe('fetchReservationsByEvent', () => {
+  it('calls the correct URL with the event id', async () => {
+    global.fetch = mockFetch(200, [])
+    await fetchReservationsByEvent(7)
+    const [url] = global.fetch.mock.calls[0]
+    expect(url).toBe('/api/reservations/event/7')
+  })
+
+  it('returns parsed JSON on success', async () => {
+    global.fetch = mockFetch(200, [{ id: 2, eventId: 7 }])
+    expect(await fetchReservationsByEvent(7)).toEqual([{ id: 2, eventId: 7 }])
+  })
+
+  it('throws with the server message on failure', async () => {
+    global.fetch = mockFetch(404, { message: 'Not found' })
+    await expect(fetchReservationsByEvent(99)).rejects.toThrow('Not found')
+  })
+})
+
+describe('createReservation', () => {
+  const payload = { userId: 1, eventId: 2 }
+
+  it('returns parsed JSON on success', async () => {
+    global.fetch = mockFetch(200, { id: 10 })
+    expect(await createReservation(payload)).toEqual({ id: 10 })
+  })
+
+  it('uses POST method', async () => {
+    global.fetch = mockFetch(200, { id: 10 })
+    await createReservation(payload)
+    const [, options] = global.fetch.mock.calls[0]
+    expect(options.method).toBe('POST')
+  })
+
+  it('serializes the payload as JSON', async () => {
+    global.fetch = mockFetch(200, { id: 10 })
+    await createReservation(payload)
+    const [, options] = global.fetch.mock.calls[0]
+    expect(options.body).toBe(JSON.stringify(payload))
+  })
+
+  it('throws with the server message on failure', async () => {
+    global.fetch = mockFetch(409, { message: 'Already reserved' })
+    await expect(createReservation(payload)).rejects.toThrow('Already reserved')
+  })
+})
+
+describe('cancelReservation', () => {
+  it('returns parsed JSON on success', async () => {
+    global.fetch = mockFetch(200, { id: 5, status: 'CANCELLED' })
+    expect(await cancelReservation(5)).toEqual({ id: 5, status: 'CANCELLED' })
+  })
+
+  it('uses PATCH method', async () => {
+    global.fetch = mockFetch(200, {})
+    await cancelReservation(5)
+    const [, options] = global.fetch.mock.calls[0]
+    expect(options.method).toBe('PATCH')
+  })
+
+  it('calls the correct cancel URL', async () => {
+    global.fetch = mockFetch(200, {})
+    await cancelReservation(5)
+    const [url] = global.fetch.mock.calls[0]
+    expect(url).toBe('/api/reservations/5/cancel')
+  })
+
+  it('throws with the server message on failure', async () => {
+    global.fetch = mockFetch(400, { message: 'Cannot cancel' })
+    await expect(cancelReservation(5)).rejects.toThrow('Cannot cancel')
+  })
+})

--- a/src/frontend/src/auth/authStorage.test.js
+++ b/src/frontend/src/auth/authStorage.test.js
@@ -1,0 +1,117 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+import {
+  getStoredAuthSession,
+  persistAuthSession,
+  clearAuthSession,
+  isUnauthorizedError,
+  AUTH_CHANGE_EVENT,
+} from './authStorage'
+
+const KEY = 'letsgettesty.auth'
+
+beforeEach(() => {
+  localStorage.clear()
+})
+
+describe('getStoredAuthSession', () => {
+  it('returns null when nothing is stored', () => {
+    expect(getStoredAuthSession()).toBeNull()
+  })
+
+  it('returns the session when a valid session is stored', () => {
+    const session = { token: 'abc123', role: 'USER' }
+    localStorage.setItem(KEY, JSON.stringify(session))
+    expect(getStoredAuthSession()).toEqual(session)
+  })
+
+  it('returns null when token is an empty string', () => {
+    localStorage.setItem(KEY, JSON.stringify({ token: '' }))
+    expect(getStoredAuthSession()).toBeNull()
+  })
+
+  it('returns null when token is only whitespace', () => {
+    localStorage.setItem(KEY, JSON.stringify({ token: '   ' }))
+    expect(getStoredAuthSession()).toBeNull()
+  })
+
+  it('returns null when token is not a string', () => {
+    localStorage.setItem(KEY, JSON.stringify({ token: 123 }))
+    expect(getStoredAuthSession()).toBeNull()
+  })
+
+  it('returns null when stored JSON is malformed', () => {
+    localStorage.setItem(KEY, 'not-valid-json')
+    expect(getStoredAuthSession()).toBeNull()
+  })
+
+  it('returns null when stored value is the string "null"', () => {
+    localStorage.setItem(KEY, 'null')
+    expect(getStoredAuthSession()).toBeNull()
+  })
+})
+
+describe('persistAuthSession', () => {
+  it('writes the session to localStorage', () => {
+    const session = { token: 'tok123', role: 'USER' }
+    persistAuthSession(session)
+    expect(JSON.parse(localStorage.getItem(KEY))).toEqual(session)
+  })
+
+  it('dispatches an auth-change event', () => {
+    let fired = false
+    window.addEventListener(AUTH_CHANGE_EVENT, () => { fired = true }, { once: true })
+    persistAuthSession({ token: 'tok' })
+    expect(fired).toBe(true)
+  })
+
+  it('overwrites a previously stored session', () => {
+    persistAuthSession({ token: 'old' })
+    persistAuthSession({ token: 'new' })
+    expect(JSON.parse(localStorage.getItem(KEY)).token).toBe('new')
+  })
+})
+
+describe('clearAuthSession', () => {
+  it('removes the session from localStorage', () => {
+    localStorage.setItem(KEY, JSON.stringify({ token: 'tok' }))
+    clearAuthSession()
+    expect(localStorage.getItem(KEY)).toBeNull()
+  })
+
+  it('dispatches an auth-change event', () => {
+    let fired = false
+    window.addEventListener(AUTH_CHANGE_EVENT, () => { fired = true }, { once: true })
+    clearAuthSession()
+    expect(fired).toBe(true)
+  })
+
+  it('does not throw when nothing is stored', () => {
+    expect(() => clearAuthSession()).not.toThrow()
+  })
+})
+
+describe('isUnauthorizedError', () => {
+  it('returns true for status 401', () => {
+    expect(isUnauthorizedError({ status: 401 })).toBe(true)
+  })
+
+  it('returns false for status 403', () => {
+    expect(isUnauthorizedError({ status: 403 })).toBe(false)
+  })
+
+  it('returns false for status 500', () => {
+    expect(isUnauthorizedError({ status: 500 })).toBe(false)
+  })
+
+  it('returns false for null', () => {
+    expect(isUnauthorizedError(null)).toBe(false)
+  })
+
+  it('returns false for undefined', () => {
+    expect(isUnauthorizedError(undefined)).toBe(false)
+  })
+
+  it('returns false when error has no status property', () => {
+    expect(isUnauthorizedError(new Error('oops'))).toBe(false)
+  })
+})

--- a/src/frontend/src/components/Header.test.jsx
+++ b/src/frontend/src/components/Header.test.jsx
@@ -1,0 +1,118 @@
+import { render, screen, fireEvent } from '@testing-library/react'
+import { MemoryRouter } from 'react-router-dom'
+import { describe, it, expect, vi } from 'vitest'
+import Header from './Header'
+
+function renderHeader(authSession, onLogout = vi.fn(), initialPath = '/') {
+  return render(
+    <MemoryRouter initialEntries={[initialPath]}>
+      <Header authSession={authSession} onLogout={onLogout} />
+    </MemoryRouter>
+  )
+}
+
+describe('Header — unauthenticated (no session)', () => {
+  it('shows the Customer link', () => {
+    renderHeader(null)
+    expect(screen.getByText('Customer')).toBeInTheDocument()
+  })
+
+  it('shows the Admin link', () => {
+    renderHeader(null)
+    expect(screen.getByText('Admin')).toBeInTheDocument()
+  })
+
+  it('does not show the Logout button', () => {
+    renderHeader(null)
+    expect(screen.queryByText('Logout')).not.toBeInTheDocument()
+  })
+
+  it('does not show role-specific nav links', () => {
+    renderHeader(null)
+    expect(screen.queryByText('Events')).not.toBeInTheDocument()
+    expect(screen.queryByText('My Tickets')).not.toBeInTheDocument()
+    expect(screen.queryByText('Add Event')).not.toBeInTheDocument()
+    expect(screen.queryByText('Edit Event')).not.toBeInTheDocument()
+  })
+})
+
+describe('Header — USER role', () => {
+  const session = { role: 'USER', token: 'tok' }
+
+  it('shows the Events link', () => {
+    renderHeader(session)
+    expect(screen.getByText('Events')).toBeInTheDocument()
+  })
+
+  it('shows the My Tickets link', () => {
+    renderHeader(session)
+    expect(screen.getByText('My Tickets')).toBeInTheDocument()
+  })
+
+  it('shows the Logout button', () => {
+    renderHeader(session)
+    expect(screen.getByText('Logout')).toBeInTheDocument()
+  })
+
+  it('does not show admin-only links', () => {
+    renderHeader(session)
+    expect(screen.queryByText('Add Event')).not.toBeInTheDocument()
+    expect(screen.queryByText('Edit Event')).not.toBeInTheDocument()
+  })
+
+  it('calls onLogout when Logout is clicked', () => {
+    const onLogout = vi.fn()
+    renderHeader(session, onLogout)
+    fireEvent.click(screen.getByText('Logout'))
+    expect(onLogout).toHaveBeenCalledOnce()
+  })
+})
+
+describe('Header — ADMIN role', () => {
+  const session = { role: 'ADMIN', token: 'tok' }
+
+  it('shows the Add Event link', () => {
+    renderHeader(session)
+    expect(screen.getByText('Add Event')).toBeInTheDocument()
+  })
+
+  it('shows the Edit Event link', () => {
+    renderHeader(session)
+    expect(screen.getByText('Edit Event')).toBeInTheDocument()
+  })
+
+  it('shows the Logout button', () => {
+    renderHeader(session)
+    expect(screen.getByText('Logout')).toBeInTheDocument()
+  })
+
+  it('does not show user-only links', () => {
+    renderHeader(session)
+    expect(screen.queryByText('Events')).not.toBeInTheDocument()
+    expect(screen.queryByText('My Tickets')).not.toBeInTheDocument()
+  })
+})
+
+describe('Header — active link highlighting', () => {
+  it('marks the current path link as active for USER', () => {
+    renderHeader({ role: 'USER', token: 'tok' }, vi.fn(), '/reservations')
+    expect(screen.getByText('My Tickets')).toHaveClass('active')
+  })
+
+  it('does not mark non-current links as active', () => {
+    renderHeader({ role: 'USER', token: 'tok' }, vi.fn(), '/reservations')
+    expect(screen.getByText('Events')).not.toHaveClass('active')
+  })
+
+  it('marks Add Event as active when on that path', () => {
+    renderHeader({ role: 'ADMIN', token: 'tok' }, vi.fn(), '/admin/add-events')
+    expect(screen.getByText('Add Event')).toHaveClass('active')
+  })
+})
+
+describe('Header — logo', () => {
+  it('renders the LetsGetTesty logo', () => {
+    renderHeader(null)
+    expect(screen.getByText('LetsGetTesty')).toBeInTheDocument()
+  })
+})

--- a/src/frontend/src/data/events.test.js
+++ b/src/frontend/src/data/events.test.js
@@ -1,0 +1,210 @@
+import { describe, it, expect } from 'vitest'
+import {
+  formatEventDate,
+  mapEventFromApi,
+  buildCreateEventPayload,
+  buildUpdateEventPayload,
+  buildEventFormFromEvent,
+} from './events'
+
+describe('formatEventDate', () => {
+  it('returns empty string for null', () => {
+    expect(formatEventDate(null)).toBe('')
+  })
+
+  it('returns empty string for empty string', () => {
+    expect(formatEventDate('')).toBe('')
+  })
+
+  it('formats a calendar date string (YYYY-MM-DD)', () => {
+    const result = formatEventDate('2025-06-15')
+    expect(result).toMatch(/2025/)
+    expect(result).toMatch(/jun/i)
+  })
+
+  it('formats an ISO datetime string', () => {
+    const result = formatEventDate('2025-06-15T18:00:00')
+    expect(result).toMatch(/2025/)
+    expect(result).toMatch(/jun/i)
+  })
+
+  it('returns a non-empty string for a valid date', () => {
+    expect(formatEventDate('2025-01-01')).not.toBe('')
+  })
+})
+
+describe('mapEventFromApi', () => {
+  const baseApi = {
+    id: 1,
+    title: 'Test Event',
+    description: 'A description',
+    location: 'Montreal',
+    capacity: 100,
+    price: 25.0,
+    category: 'MOVIE',
+    startsAt: '2025-06-15T18:00:00',
+    isCancelled: false,
+  }
+
+  it('maps all fields correctly', () => {
+    expect(mapEventFromApi(baseApi)).toEqual({
+      id: 1,
+      title: 'Test Event',
+      description: 'A description',
+      location: 'Montreal',
+      capacity: 100,
+      price: 25.0,
+      category: 'Movies',
+      date: '2025-06-15',
+      isCancelled: false,
+    })
+  })
+
+  it('defaults description to empty string when null', () => {
+    expect(mapEventFromApi({ ...baseApi, description: null }).description).toBe('')
+  })
+
+  it('defaults price to 0 when missing', () => {
+    const { price, ...rest } = baseApi
+    expect(mapEventFromApi(rest).price).toBe(0)
+  })
+
+  it('uses the raw category string when not in CATEGORY_LABEL', () => {
+    expect(mapEventFromApi({ ...baseApi, category: 'UNKNOWN' }).category).toBe('UNKNOWN')
+  })
+
+  it('maps known API categories to their labels', () => {
+    expect(mapEventFromApi({ ...baseApi, category: 'CONCERT' }).category).toBe('Concerts')
+    expect(mapEventFromApi({ ...baseApi, category: 'SPORT' }).category).toBe('Sports')
+    expect(mapEventFromApi({ ...baseApi, category: 'TRAVEL' }).category).toBe('Travel')
+  })
+
+  it('extracts the date portion from startsAt', () => {
+    expect(mapEventFromApi(baseApi).date).toBe('2025-06-15')
+  })
+
+  it('sets date to empty string when startsAt is missing', () => {
+    const { startsAt, ...rest } = baseApi
+    expect(mapEventFromApi(rest).date).toBe('')
+  })
+
+  it('sets isCancelled to false when not explicitly true', () => {
+    expect(mapEventFromApi({ ...baseApi, isCancelled: undefined }).isCancelled).toBe(false)
+    expect(mapEventFromApi({ ...baseApi, isCancelled: false }).isCancelled).toBe(false)
+  })
+
+  it('sets isCancelled to true when explicitly true', () => {
+    expect(mapEventFromApi({ ...baseApi, isCancelled: true }).isCancelled).toBe(true)
+  })
+})
+
+describe('buildCreateEventPayload', () => {
+  const validForm = {
+    title: '  My Event  ',
+    category: 'Movies',
+    location: '  Montreal  ',
+    date: '2025-06-15',
+    capacity: '100',
+    price: '25',
+  }
+
+  it('returns a correct payload for a valid form', () => {
+    expect(buildCreateEventPayload(validForm)).toEqual({
+      title: 'My Event',
+      description: null,
+      category: 'MOVIE',
+      location: 'Montreal',
+      startsAt: '2025-06-15T18:00:00',
+      endsAt: null,
+      capacity: 100,
+      price: 25,
+    })
+  })
+
+  it('trims whitespace from title and location', () => {
+    const result = buildCreateEventPayload(validForm)
+    expect(result.title).toBe('My Event')
+    expect(result.location).toBe('Montreal')
+  })
+
+  it('converts capacity and price to numbers', () => {
+    const result = buildCreateEventPayload(validForm)
+    expect(typeof result.capacity).toBe('number')
+    expect(typeof result.price).toBe('number')
+  })
+
+  it('throws for an invalid category', () => {
+    expect(() => buildCreateEventPayload({ ...validForm, category: 'InvalidCat' })).toThrow('Invalid category.')
+  })
+
+  it('maps all valid category options correctly', () => {
+    const cases = [
+      ['Movies', 'MOVIE'],
+      ['Concerts', 'CONCERT'],
+      ['Sports', 'SPORT'],
+      ['Travel', 'TRAVEL'],
+    ]
+    for (const [cat, expected] of cases) {
+      expect(buildCreateEventPayload({ ...validForm, category: cat }).category).toBe(expected)
+    }
+  })
+
+  it('formats the startsAt timestamp from the date field', () => {
+    const result = buildCreateEventPayload({ ...validForm, date: '2025-12-31' })
+    expect(result.startsAt).toBe('2025-12-31T18:00:00')
+  })
+
+  it('always sets description and endsAt to null', () => {
+    const result = buildCreateEventPayload(validForm)
+    expect(result.description).toBeNull()
+    expect(result.endsAt).toBeNull()
+  })
+})
+
+describe('buildUpdateEventPayload', () => {
+  const form = { title: 'T', category: 'Concerts', location: 'L', date: '2025-01-01', capacity: '10', price: '0' }
+
+  it('produces the same result as buildCreateEventPayload', () => {
+    expect(buildUpdateEventPayload(form)).toEqual(buildCreateEventPayload(form))
+  })
+})
+
+describe('buildEventFormFromEvent', () => {
+  it('maps event fields to form fields', () => {
+    const event = { title: 'T', date: '2025-06-15', category: 'Movies', location: 'MTL', price: 10, capacity: 50 }
+    expect(buildEventFormFromEvent(event)).toEqual({
+      title: 'T',
+      date: '2025-06-15',
+      category: 'Movies',
+      location: 'MTL',
+      price: '10',
+      capacity: '50',
+    })
+  })
+
+  it('returns defaults when event is null', () => {
+    expect(buildEventFormFromEvent(null)).toEqual({
+      title: '',
+      date: '',
+      category: 'Movies',
+      location: '',
+      price: '0',
+      capacity: '50',
+    })
+  })
+
+  it('returns defaults when event is undefined', () => {
+    const result = buildEventFormFromEvent(undefined)
+    expect(result.title).toBe('')
+    expect(result.category).toBe('Movies')
+    expect(result.price).toBe('0')
+    expect(result.capacity).toBe('50')
+  })
+
+  it('converts price and capacity to strings', () => {
+    const event = { title: 'T', date: '2025-01-01', category: 'Sports', location: 'L', price: 99, capacity: 200 }
+    const result = buildEventFormFromEvent(event)
+    expect(result.price).toBe('99')
+    expect(result.capacity).toBe('200')
+  })
+})

--- a/src/frontend/src/data/reservations.test.js
+++ b/src/frontend/src/data/reservations.test.js
@@ -1,0 +1,61 @@
+import { describe, it, expect } from 'vitest'
+import { mapReservationFromApi, buildCreateReservationPayload } from './reservations'
+
+describe('mapReservationFromApi', () => {
+  const baseApi = {
+    id: 1,
+    userId: 10,
+    eventId: 20,
+    status: 'CONFIRMED',
+    createdAt: '2025-01-01T00:00:00',
+    cancelledAt: null,
+  }
+
+  it('maps all fields correctly', () => {
+    expect(mapReservationFromApi(baseApi)).toEqual({
+      id: 1,
+      userId: 10,
+      eventId: 20,
+      status: 'CONFIRMED',
+      createdAt: '2025-01-01T00:00:00',
+      cancelledAt: null,
+      isCancelled: false,
+    })
+  })
+
+  it('sets isCancelled to true for CANCELLED status', () => {
+    const result = mapReservationFromApi({ ...baseApi, status: 'CANCELLED', cancelledAt: '2025-02-01T00:00:00' })
+    expect(result.isCancelled).toBe(true)
+    expect(result.status).toBe('CANCELLED')
+  })
+
+  it('sets isCancelled to false for CONFIRMED status', () => {
+    expect(mapReservationFromApi(baseApi).isCancelled).toBe(false)
+  })
+
+  it('uses the raw status string for unknown status values', () => {
+    expect(mapReservationFromApi({ ...baseApi, status: 'PENDING' }).status).toBe('PENDING')
+  })
+
+  it('defaults createdAt to empty string when missing', () => {
+    const { createdAt, ...rest } = baseApi
+    expect(mapReservationFromApi(rest).createdAt).toBe('')
+  })
+
+  it('defaults cancelledAt to null when missing', () => {
+    const { cancelledAt, ...rest } = baseApi
+    expect(mapReservationFromApi(rest).cancelledAt).toBeNull()
+  })
+})
+
+describe('buildCreateReservationPayload', () => {
+  it('returns an object with userId and eventId', () => {
+    expect(buildCreateReservationPayload(5, 10)).toEqual({ userId: 5, eventId: 10 })
+  })
+
+  it('preserves the exact values passed in', () => {
+    const result = buildCreateReservationPayload(42, 99)
+    expect(result.userId).toBe(42)
+    expect(result.eventId).toBe(99)
+  })
+})

--- a/src/frontend/src/pages/AuthPage.test.jsx
+++ b/src/frontend/src/pages/AuthPage.test.jsx
@@ -1,0 +1,180 @@
+import { render, screen, fireEvent, waitFor } from '@testing-library/react'
+import { MemoryRouter } from 'react-router-dom'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import AuthPage from './AuthPage'
+
+vi.mock('react-router-dom', async () => {
+  const actual = await vi.importActual('react-router-dom')
+  return { ...actual, useNavigate: () => vi.fn() }
+})
+
+vi.mock('../auth/authStorage', () => ({
+  persistAuthSession: vi.fn(),
+}))
+
+function renderAuth(props = {}) {
+  return render(
+    <MemoryRouter>
+      <AuthPage {...props} />
+    </MemoryRouter>
+  )
+}
+
+describe('AuthPage — default (login mode, USER)', () => {
+  it('renders the LGT logo', () => {
+    renderAuth()
+    expect(screen.getByText('LGT')).toBeInTheDocument()
+  })
+
+  it('shows Sign In and Register tabs', () => {
+    renderAuth()
+    // Both the tab and submit button say "Sign In", so use getAllByText
+    expect(screen.getAllByText('Sign In').length).toBeGreaterThan(0)
+    expect(screen.getByText('Register')).toBeInTheDocument()
+  })
+
+  it('shows a Sign In submit button', () => {
+    renderAuth()
+    // Both the tab and the submit button have "Sign In" text
+    const signInButtons = screen.getAllByRole('button', { name: /^sign in$/i })
+    const submitBtn = signInButtons.find(b => b.type === 'submit')
+    expect(submitBtn).toBeTruthy()
+  })
+
+  it('shows email and password fields', () => {
+    renderAuth()
+    expect(screen.getByPlaceholderText('you@example.com')).toBeInTheDocument()
+    expect(screen.getByPlaceholderText('••••••••')).toBeInTheDocument()
+  })
+})
+
+describe('AuthPage — admin mode', () => {
+  it('shows LGT Admin logo', () => {
+    renderAuth({ authRole: 'ADMIN', allowRegister: false })
+    expect(screen.getByText('LGT Admin')).toBeInTheDocument()
+  })
+
+  it('shows Administrator label instead of tabs', () => {
+    renderAuth({ authRole: 'ADMIN', allowRegister: false })
+    expect(screen.getByText('Administrator')).toBeInTheDocument()
+    expect(screen.queryByText('Register')).not.toBeInTheDocument()
+  })
+
+  it('shows Admin Sign In button', () => {
+    renderAuth({ authRole: 'ADMIN', allowRegister: false })
+    expect(screen.getByRole('button', { name: /admin sign in/i })).toBeInTheDocument()
+  })
+})
+
+describe('AuthPage — switching to register mode', () => {
+  beforeEach(() => {
+    renderAuth({ allowRegister: true })
+    fireEvent.click(screen.getByText('Register'))
+  })
+
+  it('shows Full Name field', () => {
+    expect(screen.getByPlaceholderText('Jane Doe')).toBeInTheDocument()
+  })
+
+  it('shows Create Account submit button', () => {
+    expect(screen.getByRole('button', { name: /create account/i })).toBeInTheDocument()
+  })
+})
+
+describe('AuthPage — password validation (register mode)', () => {
+  beforeEach(() => {
+    renderAuth({ allowRegister: true })
+    fireEvent.click(screen.getByText('Register'))
+  })
+
+  it('shows error when password is too short', async () => {
+    fireEvent.change(screen.getByPlaceholderText('Jane Doe'), { target: { value: 'Jane' } })
+    fireEvent.change(screen.getByPlaceholderText('you@example.com'), { target: { value: 'test@test.com' } })
+    fireEvent.change(screen.getByPlaceholderText('••••••••'), { target: { value: 'abc' } })
+    fireEvent.click(screen.getByRole('button', { name: /create account/i }))
+    await waitFor(() => {
+      expect(screen.getByText(/at least 6 characters/i)).toBeInTheDocument()
+    })
+  })
+
+  it('shows error when password has no lowercase letter', async () => {
+    fireEvent.change(screen.getByPlaceholderText('Jane Doe'), { target: { value: 'Jane' } })
+    fireEvent.change(screen.getByPlaceholderText('you@example.com'), { target: { value: 'test@test.com' } })
+    fireEvent.change(screen.getByPlaceholderText('••••••••'), { target: { value: 'ABC123!' } })
+    fireEvent.click(screen.getByRole('button', { name: /create account/i }))
+    await waitFor(() => {
+      expect(screen.getByText(/lowercase letter/i)).toBeInTheDocument()
+    })
+  })
+
+  it('shows error when password has no uppercase letter', async () => {
+    fireEvent.change(screen.getByPlaceholderText('Jane Doe'), { target: { value: 'Jane' } })
+    fireEvent.change(screen.getByPlaceholderText('you@example.com'), { target: { value: 'test@test.com' } })
+    fireEvent.change(screen.getByPlaceholderText('••••••••'), { target: { value: 'abc123!' } })
+    fireEvent.click(screen.getByRole('button', { name: /create account/i }))
+    await waitFor(() => {
+      expect(screen.getByText(/uppercase letter/i)).toBeInTheDocument()
+    })
+  })
+
+  it('shows error when password has no number', async () => {
+    fireEvent.change(screen.getByPlaceholderText('Jane Doe'), { target: { value: 'Jane' } })
+    fireEvent.change(screen.getByPlaceholderText('you@example.com'), { target: { value: 'test@test.com' } })
+    fireEvent.change(screen.getByPlaceholderText('••••••••'), { target: { value: 'Abcdef!' } })
+    fireEvent.click(screen.getByRole('button', { name: /create account/i }))
+    await waitFor(() => {
+      expect(screen.getByText(/must include a number/i)).toBeInTheDocument()
+    })
+  })
+
+  it('shows error when password has no special character', async () => {
+    fireEvent.change(screen.getByPlaceholderText('Jane Doe'), { target: { value: 'Jane' } })
+    fireEvent.change(screen.getByPlaceholderText('you@example.com'), { target: { value: 'test@test.com' } })
+    fireEvent.change(screen.getByPlaceholderText('••••••••'), { target: { value: 'Abcdef1' } })
+    fireEvent.click(screen.getByRole('button', { name: /create account/i }))
+    await waitFor(() => {
+      expect(screen.getByText(/special character/i)).toBeInTheDocument()
+    })
+  })
+
+  it('does not show password error in login mode', () => {
+    fireEvent.click(screen.getByText('Sign In'))
+    expect(screen.queryByText(/at least 6 characters/i)).not.toBeInTheDocument()
+  })
+})
+
+describe('AuthPage — contact type toggle', () => {
+  it('shows email input by default', () => {
+    renderAuth()
+    expect(screen.getByPlaceholderText('you@example.com')).toHaveAttribute('type', 'email')
+  })
+
+  it('switches to phone input when Phone is selected', () => {
+    renderAuth()
+    fireEvent.click(screen.getByText('Phone'))
+    expect(screen.getByPlaceholderText('514-555-0100')).toHaveAttribute('type', 'tel')
+  })
+
+  it('switches back to email when Email is selected', () => {
+    renderAuth()
+    fireEvent.click(screen.getByText('Phone'))
+    fireEvent.click(screen.getByText('Email'))
+    expect(screen.getByPlaceholderText('you@example.com')).toHaveAttribute('type', 'email')
+  })
+})
+
+describe('AuthPage — mode switching clears errors', () => {
+  it('clears errors when switching between login and register', async () => {
+    renderAuth({ allowRegister: true })
+    fireEvent.click(screen.getByText('Register'))
+    fireEvent.change(screen.getByPlaceholderText('Jane Doe'), { target: { value: 'Jane' } })
+    fireEvent.change(screen.getByPlaceholderText('you@example.com'), { target: { value: 'test@test.com' } })
+    fireEvent.change(screen.getByPlaceholderText('••••••••'), { target: { value: 'abc' } })
+    fireEvent.click(screen.getByRole('button', { name: /create account/i }))
+    await waitFor(() => {
+      expect(screen.getByText(/at least 6 characters/i)).toBeInTheDocument()
+    })
+    fireEvent.click(screen.getAllByText('Sign In')[0])
+    expect(screen.queryByText(/at least 6 characters/i)).not.toBeInTheDocument()
+  })
+})

--- a/src/frontend/src/pages/HomePage.test.jsx
+++ b/src/frontend/src/pages/HomePage.test.jsx
@@ -1,0 +1,160 @@
+import { render, screen, fireEvent } from '@testing-library/react'
+import { describe, it, expect, vi } from 'vitest'
+import HomePage from './HomePage'
+
+const sampleEvents = [
+  { id: 1, title: 'Rock Concert', category: 'Concerts', location: 'Montreal', date: '2025-08-01', price: 50, capacity: 200, isCancelled: false },
+  { id: 2, title: 'Art Exhibition', category: 'Movies', location: 'Toronto', date: '2025-09-15', price: 0, capacity: 100, isCancelled: false },
+  { id: 3, title: 'Football Game', category: 'Sports', location: 'Ottawa', date: '2025-07-01', price: 20, capacity: 50, isCancelled: true },
+]
+
+function renderHome(props = {}) {
+  return render(
+    <HomePage
+      events={props.events ?? sampleEvents}
+      eventsLoading={props.eventsLoading ?? false}
+      eventsError={props.eventsError ?? null}
+      reservations={props.reservations ?? []}
+      onReserve={props.onReserve ?? vi.fn()}
+    />
+  )
+}
+
+describe('HomePage — rendering', () => {
+  it('renders all events by default', () => {
+    renderHome()
+    expect(screen.getByText('Rock Concert')).toBeInTheDocument()
+    expect(screen.getByText('Art Exhibition')).toBeInTheDocument()
+    expect(screen.getByText('Football Game')).toBeInTheDocument()
+  })
+
+  it('shows loading message when eventsLoading is true', () => {
+    renderHome({ eventsLoading: true })
+    expect(screen.getByText('Loading events…')).toBeInTheDocument()
+  })
+
+  it('hides events grid while loading', () => {
+    renderHome({ eventsLoading: true })
+    expect(screen.queryByText('Rock Concert')).not.toBeInTheDocument()
+  })
+
+  it('shows error message with role="alert" when eventsError is set', () => {
+    renderHome({ eventsError: 'Failed to load events' })
+    expect(screen.getByRole('alert')).toHaveTextContent('Failed to load events')
+  })
+
+  it('shows no-results message when events list is empty', () => {
+    renderHome({ events: [] })
+    expect(screen.getByText('No events match your filters.')).toBeInTheDocument()
+  })
+})
+
+describe('HomePage — filtering by category', () => {
+  it('shows only matching events when a category is selected', () => {
+    renderHome()
+    fireEvent.click(screen.getByRole('button', { name: 'Concerts' }))
+    expect(screen.getByText('Rock Concert')).toBeInTheDocument()
+    expect(screen.queryByText('Art Exhibition')).not.toBeInTheDocument()
+  })
+
+  it('shows all events when All is selected', () => {
+    renderHome()
+    fireEvent.click(screen.getByRole('button', { name: 'Concerts' }))
+    fireEvent.click(screen.getByRole('button', { name: 'All' }))
+    expect(screen.getByText('Rock Concert')).toBeInTheDocument()
+    expect(screen.getByText('Art Exhibition')).toBeInTheDocument()
+  })
+
+  it('shows no-results when no events match the selected category', () => {
+    renderHome()
+    fireEvent.click(screen.getByRole('button', { name: 'Travel' }))
+    expect(screen.getByText('No events match your filters.')).toBeInTheDocument()
+  })
+})
+
+describe('HomePage — filtering by search', () => {
+  it('filters by title (case-insensitive)', () => {
+    renderHome()
+    fireEvent.change(screen.getByPlaceholderText('Search events or locations…'), { target: { value: 'rock' } })
+    expect(screen.getByText('Rock Concert')).toBeInTheDocument()
+    expect(screen.queryByText('Art Exhibition')).not.toBeInTheDocument()
+  })
+
+  it('filters by location (case-insensitive)', () => {
+    renderHome()
+    fireEvent.change(screen.getByPlaceholderText('Search events or locations…'), { target: { value: 'toronto' } })
+    expect(screen.getByText('Art Exhibition')).toBeInTheDocument()
+    expect(screen.queryByText('Rock Concert')).not.toBeInTheDocument()
+  })
+
+  it('shows no-results when nothing matches the search', () => {
+    renderHome()
+    fireEvent.change(screen.getByPlaceholderText('Search events or locations…'), { target: { value: 'zzznomatch' } })
+    expect(screen.getByText('No events match your filters.')).toBeInTheDocument()
+  })
+
+  it('clears filter when search is cleared', () => {
+    renderHome()
+    fireEvent.change(screen.getByPlaceholderText('Search events or locations…'), { target: { value: 'rock' } })
+    fireEvent.change(screen.getByPlaceholderText('Search events or locations…'), { target: { value: '' } })
+    expect(screen.getByText('Art Exhibition')).toBeInTheDocument()
+  })
+})
+
+describe('HomePage — filtering by date', () => {
+  it('hides events before the selected date', () => {
+    renderHome()
+    fireEvent.change(screen.getByTitle('Filter from date'), { target: { value: '2025-09-01' } })
+    expect(screen.queryByText('Rock Concert')).not.toBeInTheDocument()
+    expect(screen.getByText('Art Exhibition')).toBeInTheDocument()
+  })
+
+  it('shows all events when date filter is cleared', () => {
+    renderHome()
+    fireEvent.change(screen.getByTitle('Filter from date'), { target: { value: '2025-09-01' } })
+    fireEvent.change(screen.getByTitle('Filter from date'), { target: { value: '' } })
+    expect(screen.getByText('Rock Concert')).toBeInTheDocument()
+  })
+})
+
+describe('HomePage — event status badges', () => {
+  it('shows Cancelled badge for cancelled events', () => {
+    renderHome()
+    expect(screen.getByText('Cancelled')).toBeInTheDocument()
+  })
+
+  it('shows Booked badge for events the user has confirmed reservations for', () => {
+    renderHome({ reservations: [{ eventId: 1, status: 'CONFIRMED' }] })
+    expect(screen.getByText('Booked')).toBeInTheDocument()
+  })
+
+  it('does not show Booked badge for CANCELLED reservations', () => {
+    renderHome({ reservations: [{ eventId: 1, status: 'CANCELLED' }] })
+    expect(screen.queryByText('Booked')).not.toBeInTheDocument()
+  })
+
+  it('shows Reserve button for available, unbooked events', () => {
+    renderHome()
+    const reserveButtons = screen.getAllByText('Reserve')
+    expect(reserveButtons.length).toBeGreaterThan(0)
+  })
+
+  it('calls onReserve with the event id when Reserve is clicked', () => {
+    const onReserve = vi.fn()
+    renderHome({ onReserve })
+    fireEvent.click(screen.getAllByText('Reserve')[0])
+    expect(onReserve).toHaveBeenCalledWith(expect.any(Number))
+  })
+})
+
+describe('HomePage — price display', () => {
+  it('shows "Free" for events with price 0', () => {
+    renderHome()
+    expect(screen.getByText('Free')).toBeInTheDocument()
+  })
+
+  it('shows the price with $ prefix for paid events', () => {
+    renderHome()
+    expect(screen.getByText('$50')).toBeInTheDocument()
+  })
+})

--- a/src/frontend/src/test/setup.js
+++ b/src/frontend/src/test/setup.js
@@ -1,0 +1,1 @@
+import '@testing-library/jest-dom'

--- a/src/frontend/vite.config.js
+++ b/src/frontend/vite.config.js
@@ -12,4 +12,10 @@ export default defineConfig({
       '/api': 'http://127.0.0.1:8080',
     },
   },
+  test: {
+    environment: 'jsdom',
+    globals: true,
+    setupFiles: './src/test/setup.js',
+    exclude: ['e2e/**', 'node_modules/**'],
+  },
 })


### PR DESCRIPTION
## Summary

- Configured **Vitest** + **React Testing Library** as the unit test runner (separate from the existing Playwright E2E tests)
- Added **147 unit tests** across 8 test files covering API clients, auth storage, data utilities, and UI components

---

## What was tested

| File | Tests |
|---|---|
| `src/data/events.test.js` | Event mapping, payload building, date formatting |
| `src/data/reservations.test.js` | Reservation mapping, payload creation |
| `src/auth/authStorage.test.js` | Session read/write, localStorage, auth-change events |
| `src/api/eventsApi.test.js` | fetch, create, update, cancel — success & error paths |
| `src/api/reservationsApi.test.js` | fetch by user/event, create, cancel — success & error paths |
| `src/components/Header.test.jsx` | Role-based nav links, active link, logout |
| `src/pages/AuthPage.test.jsx` | Login/register flow, password validation, contact toggle |
| `src/pages/HomePage.test.jsx` | Event filtering by category/search/date, badges, reserve |

---
## How to Run the Tests
To execute the unit tests:
```
cd src/frontend
npm test

```
## Results 
<img width="952" height="574" alt="image" src="https://github.com/user-attachments/assets/bfbd9def-6844-4222-9fe7-7ed3a420d6dc" />
