### PR TITLE
Add frontend unit tests for App, AddEventsPage, EditEventsPage, and R…

### DIFF
--- a/src/frontend/src/App.test.jsx
+++ b/src/frontend/src/App.test.jsx
@@ -1,0 +1,136 @@
+import { render, screen } from '@testing-library/react'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+vi.mock('./api/eventsApi', () => ({ fetchEvents: vi.fn().mockResolvedValue([]) }))
+vi.mock('./api/reservationsApi', () => ({
+  fetchReservationsByUser: vi.fn().mockResolvedValue([]),
+  createReservation: vi.fn(),
+}))
+vi.mock('./auth/authStorage', () => ({
+  getStoredAuthSession: vi.fn(),
+  clearAuthSession: vi.fn(),
+  persistAuthSession: vi.fn(),
+  isUnauthorizedError: vi.fn().mockReturnValue(false),
+  AUTH_CHANGE_EVENT: 'letsgettesty:auth-change',
+}))
+vi.mock('./pages/HomePage', () => ({ default: () => 'HomePage' }))
+vi.mock('./pages/AddEventsPage', () => ({ default: () => 'AddEventsPage' }))
+vi.mock('./pages/EditEventsPage', () => ({ default: () => 'EditEventsPage' }))
+vi.mock('./pages/AuthPage', () => ({ default: () => 'AuthPage' }))
+vi.mock('./pages/ReservationsPage', () => ({ default: () => 'ReservationsPage' }))
+vi.mock('./components/Header', () => ({ default: () => null }))
+
+import { getStoredAuthSession } from './auth/authStorage'
+import App from './App'
+
+function navigate(path) {
+  window.history.pushState({}, '', path)
+}
+
+describe('App — unauthenticated routing', () => {
+  beforeEach(() => {
+    getStoredAuthSession.mockReturnValue(null)
+  })
+
+  it('redirects / to /auth when not authenticated', () => {
+    navigate('/')
+    render(<App />)
+    expect(screen.getByText('AuthPage')).toBeInTheDocument()
+  })
+
+  it('shows AuthPage at /auth', () => {
+    navigate('/auth')
+    render(<App />)
+    expect(screen.getByText('AuthPage')).toBeInTheDocument()
+  })
+
+  it('shows admin AuthPage at /admin', () => {
+    navigate('/admin')
+    render(<App />)
+    expect(screen.getByText('AuthPage')).toBeInTheDocument()
+  })
+
+  it('redirects /admin/add-events to /admin login when not authenticated', () => {
+    navigate('/admin/add-events')
+    render(<App />)
+    expect(screen.getByText('AuthPage')).toBeInTheDocument()
+  })
+
+  it('redirects unknown route to /auth when not authenticated', () => {
+    navigate('/unknown-route')
+    render(<App />)
+    expect(screen.getByText('AuthPage')).toBeInTheDocument()
+  })
+})
+
+describe('App — USER routing', () => {
+  beforeEach(() => {
+    getStoredAuthSession.mockReturnValue({ id: 1, token: 'user-tok', role: 'USER' })
+  })
+
+  it('shows HomePage at / for USER', () => {
+    navigate('/')
+    render(<App />)
+    expect(screen.getByText('HomePage')).toBeInTheDocument()
+  })
+
+  it('redirects /auth to / when USER is authenticated', () => {
+    navigate('/auth')
+    render(<App />)
+    expect(screen.getByText('HomePage')).toBeInTheDocument()
+  })
+
+  it('shows ReservationsPage at /reservations for USER', () => {
+    navigate('/reservations')
+    render(<App />)
+    expect(screen.getByText('ReservationsPage')).toBeInTheDocument()
+  })
+
+  it('redirects /admin/add-events to / for USER role', () => {
+    navigate('/admin/add-events')
+    render(<App />)
+    expect(screen.getByText('HomePage')).toBeInTheDocument()
+  })
+
+  it('redirects /admin/edit-events to / for USER role', () => {
+    navigate('/admin/edit-events')
+    render(<App />)
+    expect(screen.getByText('HomePage')).toBeInTheDocument()
+  })
+})
+
+describe('App — ADMIN routing', () => {
+  beforeEach(() => {
+    getStoredAuthSession.mockReturnValue({ id: 2, token: 'admin-tok', role: 'ADMIN' })
+  })
+
+  it('redirects / to /admin/add-events for ADMIN', () => {
+    navigate('/')
+    render(<App />)
+    expect(screen.getByText('AddEventsPage')).toBeInTheDocument()
+  })
+
+  it('shows AddEventsPage at /admin/add-events for ADMIN', () => {
+    navigate('/admin/add-events')
+    render(<App />)
+    expect(screen.getByText('AddEventsPage')).toBeInTheDocument()
+  })
+
+  it('shows EditEventsPage at /admin/edit-events for ADMIN', () => {
+    navigate('/admin/edit-events')
+    render(<App />)
+    expect(screen.getByText('EditEventsPage')).toBeInTheDocument()
+  })
+
+  it('redirects /auth to /admin/add-events when ADMIN is authenticated', () => {
+    navigate('/auth')
+    render(<App />)
+    expect(screen.getByText('AddEventsPage')).toBeInTheDocument()
+  })
+
+  it('redirects / to /admin/add-events for ADMIN (not HomePage)', () => {
+    navigate('/')
+    render(<App />)
+    expect(screen.queryByText('HomePage')).not.toBeInTheDocument()
+  })
+})

--- a/src/frontend/src/pages/AddEventsPage.test.jsx
+++ b/src/frontend/src/pages/AddEventsPage.test.jsx
@@ -1,0 +1,168 @@
+import { render, screen, fireEvent, waitFor } from '@testing-library/react'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import AddEventsPage from './AddEventsPage'
+
+vi.mock('../api/eventsApi', () => ({ createEvent: vi.fn() }))
+
+import { createEvent } from '../api/eventsApi'
+
+const sampleEvents = [
+  { id: 1, title: 'Rock Concert', category: 'Concerts', location: 'Montreal', date: '2025-08-01', price: 50, capacity: 200 },
+  { id: 2, title: 'Art Exhibition', category: 'Movies', location: 'Toronto', date: '2025-09-15', price: 0, capacity: 100 },
+]
+
+function renderPage(props = {}) {
+  return render(
+    <AddEventsPage
+      events={props.events ?? sampleEvents}
+      onEventsChanged={props.onEventsChanged ?? vi.fn()}
+    />
+  )
+}
+
+describe('AddEventsPage — rendering', () => {
+  it('renders the page title', () => {
+    renderPage()
+    expect(screen.getByText('Create a new event.')).toBeInTheDocument()
+  })
+
+  it('renders title and location inputs', () => {
+    renderPage()
+    expect(screen.getByPlaceholderText('Example: Montreal Comedy Night')).toBeInTheDocument()
+    expect(screen.getByPlaceholderText('Example: Bell Centre, Montreal')).toBeInTheDocument()
+  })
+
+  it('renders the Add Event submit button', () => {
+    renderPage()
+    expect(screen.getByRole('button', { name: 'Add Event' })).toBeInTheDocument()
+  })
+
+  it('shows event count in the sidebar heading', () => {
+    renderPage()
+    expect(screen.getByText('2 Recent Events')).toBeInTheDocument()
+  })
+
+  it('renders event titles in the sidebar', () => {
+    renderPage()
+    expect(screen.getByText('Rock Concert')).toBeInTheDocument()
+    expect(screen.getByText('Art Exhibition')).toBeInTheDocument()
+  })
+
+  it('shows "Free" for events with price 0', () => {
+    renderPage()
+    expect(screen.getByText('Free')).toBeInTheDocument()
+  })
+
+  it('shows price with $ for paid events', () => {
+    renderPage()
+    expect(screen.getByText('$50')).toBeInTheDocument()
+  })
+
+  it('shows 0 Recent Events when events list is empty', () => {
+    renderPage({ events: [] })
+    expect(screen.getByText('0 Recent Events')).toBeInTheDocument()
+  })
+})
+
+describe('AddEventsPage — form interaction', () => {
+  it('updates title field on input', () => {
+    renderPage()
+    const titleInput = screen.getByPlaceholderText('Example: Montreal Comedy Night')
+    fireEvent.change(titleInput, { target: { value: 'Jazz Night' } })
+    expect(titleInput.value).toBe('Jazz Night')
+  })
+
+  it('updates location field on input', () => {
+    renderPage()
+    const locationInput = screen.getByPlaceholderText('Example: Bell Centre, Montreal')
+    fireEvent.change(locationInput, { target: { value: 'Place des Arts' } })
+    expect(locationInput.value).toBe('Place des Arts')
+  })
+
+  it('category select defaults to Movies', () => {
+    renderPage()
+    expect(screen.getByDisplayValue('Movies')).toBeInTheDocument()
+  })
+
+  it('updates category when changed', () => {
+    renderPage()
+    const categorySelect = screen.getByDisplayValue('Movies')
+    fireEvent.change(categorySelect, { target: { value: 'Concerts' } })
+    expect(screen.getByDisplayValue('Concerts')).toBeInTheDocument()
+  })
+
+  it('price field defaults to 0', () => {
+    renderPage()
+    expect(screen.getByDisplayValue('0')).toBeInTheDocument()
+  })
+
+  it('capacity field defaults to 50', () => {
+    renderPage()
+    expect(screen.getByDisplayValue('50')).toBeInTheDocument()
+  })
+})
+
+describe('AddEventsPage — form submission', () => {
+  beforeEach(() => {
+    createEvent.mockReset()
+  })
+
+  it('shows success notice after adding an event', async () => {
+    createEvent.mockResolvedValue({ title: 'Jazz Night' })
+    const onEventsChanged = vi.fn().mockResolvedValue(undefined)
+    renderPage({ onEventsChanged })
+
+    fireEvent.change(screen.getByPlaceholderText('Example: Montreal Comedy Night'), { target: { value: 'Jazz Night' } })
+    fireEvent.change(screen.getByPlaceholderText('Example: Bell Centre, Montreal'), { target: { value: 'Place des Arts' } })
+    fireEvent.submit(screen.getByRole('button', { name: 'Add Event' }).closest('form'))
+
+    await waitFor(() => {
+      expect(screen.getByText('Added Jazz Night to the event list.')).toBeInTheDocument()
+    })
+    expect(onEventsChanged).toHaveBeenCalled()
+  })
+
+  it('shows error notice when createEvent fails', async () => {
+    createEvent.mockRejectedValue(new Error('Server error'))
+    renderPage()
+
+    fireEvent.change(screen.getByPlaceholderText('Example: Montreal Comedy Night'), { target: { value: 'Test Event' } })
+    fireEvent.change(screen.getByPlaceholderText('Example: Bell Centre, Montreal'), { target: { value: 'Venue' } })
+    fireEvent.submit(screen.getByRole('button', { name: 'Add Event' }).closest('form'))
+
+    await waitFor(() => {
+      expect(screen.getByText('Server error')).toBeInTheDocument()
+    })
+  })
+
+  it('disables the submit button while submitting', async () => {
+    let resolve
+    createEvent.mockReturnValue(new Promise(r => { resolve = r }))
+    const onEventsChanged = vi.fn().mockResolvedValue(undefined)
+    renderPage({ onEventsChanged })
+
+    fireEvent.change(screen.getByPlaceholderText('Example: Montreal Comedy Night'), { target: { value: 'Test Event' } })
+    fireEvent.change(screen.getByPlaceholderText('Example: Bell Centre, Montreal'), { target: { value: 'Venue' } })
+    fireEvent.submit(screen.getByRole('button', { name: 'Add Event' }).closest('form'))
+
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: 'Adding…' })).toBeDisabled()
+    })
+    resolve({ title: 'Test Event' })
+  })
+
+  it('resets the form after successful submission', async () => {
+    createEvent.mockResolvedValue({ title: 'Jazz Night' })
+    const onEventsChanged = vi.fn().mockResolvedValue(undefined)
+    renderPage({ onEventsChanged })
+
+    const titleInput = screen.getByPlaceholderText('Example: Montreal Comedy Night')
+    fireEvent.change(titleInput, { target: { value: 'Jazz Night' } })
+    fireEvent.change(screen.getByPlaceholderText('Example: Bell Centre, Montreal'), { target: { value: 'Place des Arts' } })
+    fireEvent.submit(screen.getByRole('button', { name: 'Add Event' }).closest('form'))
+
+    await waitFor(() => {
+      expect(titleInput.value).toBe('')
+    })
+  })
+})

--- a/src/frontend/src/pages/EditEventsPage.test.jsx
+++ b/src/frontend/src/pages/EditEventsPage.test.jsx
@@ -1,0 +1,213 @@
+import { render, screen, fireEvent, waitFor } from '@testing-library/react'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import EditEventsPage from './EditEventsPage'
+
+vi.mock('../api/eventsApi', () => ({
+  updateEvent: vi.fn(),
+  cancelEvent: vi.fn(),
+}))
+
+import { updateEvent, cancelEvent } from '../api/eventsApi'
+
+const activeEvents = [
+  { id: 1, title: 'Rock Concert', category: 'Concerts', location: 'Montreal', date: '2025-08-01', price: 50, capacity: 200, isCancelled: false },
+  { id: 2, title: 'Art Exhibition', category: 'Movies', location: 'Toronto', date: '2025-09-15', price: 0, capacity: 100, isCancelled: false },
+]
+
+const mixedEvents = [
+  ...activeEvents,
+  { id: 3, title: 'Old Show', category: 'Movies', location: 'Ottawa', date: '2025-07-01', price: 20, capacity: 50, isCancelled: true },
+]
+
+function renderPage(props = {}) {
+  return render(
+    <EditEventsPage
+      events={props.events ?? activeEvents}
+      onEventsChanged={props.onEventsChanged ?? vi.fn()}
+    />
+  )
+}
+
+describe('EditEventsPage — rendering', () => {
+  it('renders the page title', () => {
+    renderPage()
+    expect(screen.getByText('Edit existing events.')).toBeInTheDocument()
+  })
+
+  it('shows "No editable events" option when all events are cancelled', () => {
+    renderPage({ events: [{ id: 3, title: 'Old Show', category: 'Movies', location: 'Ottawa', date: '2025-07-01', price: 20, capacity: 50, isCancelled: true }] })
+    expect(screen.getByText('No editable events')).toBeInTheDocument()
+  })
+
+  it('pre-fills form with the first non-cancelled event title', () => {
+    renderPage()
+    expect(screen.getByDisplayValue('Rock Concert')).toBeInTheDocument()
+  })
+
+  it('pre-fills location for the first selected event', () => {
+    renderPage()
+    expect(screen.getByDisplayValue('Montreal')).toBeInTheDocument()
+  })
+
+  it('shows Cancelled status pill for cancelled events in the sidebar', () => {
+    renderPage({ events: mixedEvents })
+    expect(screen.getByText('Cancelled')).toBeInTheDocument()
+  })
+
+  it('shows "Select to Edit" button for non-selected active events', () => {
+    renderPage()
+    expect(screen.getByRole('button', { name: 'Select to Edit' })).toBeInTheDocument()
+  })
+
+  it('shows "Currently Editing" for the currently selected event', () => {
+    renderPage()
+    expect(screen.getByRole('button', { name: 'Currently Editing' })).toBeInTheDocument()
+  })
+
+  it('shows "No events available." in the sidebar when events list is empty', () => {
+    renderPage({ events: [] })
+    expect(screen.getByText('No events available.')).toBeInTheDocument()
+  })
+
+  it('shows both event titles in the sidebar', () => {
+    renderPage({ events: mixedEvents })
+    expect(screen.getByText('Rock Concert')).toBeInTheDocument()
+    expect(screen.getByText('Art Exhibition')).toBeInTheDocument()
+    expect(screen.getByText('Old Show')).toBeInTheDocument()
+  })
+})
+
+describe('EditEventsPage — event selection', () => {
+  it('updates form when a different event is selected from the dropdown', () => {
+    renderPage()
+    const selects = screen.getAllByRole('combobox')
+    fireEvent.change(selects[0], { target: { value: '2' } })
+    expect(screen.getByDisplayValue('Art Exhibition')).toBeInTheDocument()
+    expect(screen.getByDisplayValue('Toronto')).toBeInTheDocument()
+  })
+
+  it('updates form when "Select to Edit" is clicked in the sidebar', () => {
+    renderPage()
+    fireEvent.click(screen.getByRole('button', { name: 'Select to Edit' }))
+    expect(screen.getByDisplayValue('Art Exhibition')).toBeInTheDocument()
+  })
+
+  it('updates location when a different event is selected', () => {
+    renderPage()
+    const selects = screen.getAllByRole('combobox')
+    fireEvent.change(selects[0], { target: { value: '2' } })
+    expect(screen.getByDisplayValue('Toronto')).toBeInTheDocument()
+  })
+})
+
+describe('EditEventsPage — form submission', () => {
+  beforeEach(() => {
+    updateEvent.mockReset()
+    cancelEvent.mockReset()
+  })
+
+  it('shows success notice after saving changes', async () => {
+    updateEvent.mockResolvedValue({ title: 'Rock Concert' })
+    const onEventsChanged = vi.fn().mockResolvedValue(undefined)
+    renderPage({ onEventsChanged })
+
+    fireEvent.submit(screen.getByRole('button', { name: 'Save Changes' }).closest('form'))
+
+    await waitFor(() => {
+      expect(screen.getByText('Updated Rock Concert.')).toBeInTheDocument()
+    })
+    expect(onEventsChanged).toHaveBeenCalled()
+  })
+
+  it('shows error notice when updateEvent fails', async () => {
+    updateEvent.mockRejectedValue(new Error('Update failed'))
+    renderPage()
+
+    fireEvent.submit(screen.getByRole('button', { name: 'Save Changes' }).closest('form'))
+
+    await waitFor(() => {
+      expect(screen.getByText('Update failed')).toBeInTheDocument()
+    })
+  })
+
+  it('disables Save Changes button while submitting', async () => {
+    let resolve
+    updateEvent.mockReturnValue(new Promise(r => { resolve = r }))
+    renderPage()
+
+    fireEvent.submit(screen.getByRole('button', { name: 'Save Changes' }).closest('form'))
+
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: 'Saving...' })).toBeDisabled()
+    })
+    resolve({ title: 'Rock Concert' })
+  })
+
+  it('disables Cancel Selected Event button while submitting', async () => {
+    let resolve
+    updateEvent.mockReturnValue(new Promise(r => { resolve = r }))
+    renderPage()
+
+    fireEvent.submit(screen.getByRole('button', { name: 'Save Changes' }).closest('form'))
+
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: 'Cancel Selected Event' })).toBeDisabled()
+    })
+    resolve({ title: 'Rock Concert' })
+  })
+})
+
+describe('EditEventsPage — cancel event', () => {
+  beforeEach(() => {
+    cancelEvent.mockReset()
+  })
+
+  it('calls cancelEvent with the selected event id', async () => {
+    cancelEvent.mockResolvedValue(undefined)
+    const onEventsChanged = vi.fn().mockResolvedValue(undefined)
+    renderPage({ onEventsChanged })
+
+    fireEvent.click(screen.getByRole('button', { name: 'Cancel Selected Event' }))
+
+    await waitFor(() => {
+      expect(cancelEvent).toHaveBeenCalledWith(1)
+    })
+    expect(onEventsChanged).toHaveBeenCalled()
+  })
+
+  it('shows success notice after cancelling an event', async () => {
+    cancelEvent.mockResolvedValue(undefined)
+    const onEventsChanged = vi.fn().mockResolvedValue(undefined)
+    renderPage({ onEventsChanged })
+
+    fireEvent.click(screen.getByRole('button', { name: 'Cancel Selected Event' }))
+
+    await waitFor(() => {
+      expect(screen.getByText('Cancelled Rock Concert.')).toBeInTheDocument()
+    })
+  })
+
+  it('shows error notice when cancelEvent fails', async () => {
+    cancelEvent.mockRejectedValue(new Error('Cannot cancel'))
+    renderPage()
+
+    fireEvent.click(screen.getByRole('button', { name: 'Cancel Selected Event' }))
+
+    await waitFor(() => {
+      expect(screen.getByText('Cannot cancel')).toBeInTheDocument()
+    })
+  })
+
+  it('shows "Cancelling..." on the button while the request is in flight', async () => {
+    let resolve
+    cancelEvent.mockReturnValue(new Promise(r => { resolve = r }))
+    renderPage()
+
+    fireEvent.click(screen.getByRole('button', { name: 'Cancel Selected Event' }))
+
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: 'Cancelling...' })).toBeInTheDocument()
+    })
+    resolve()
+  })
+})

--- a/src/frontend/src/pages/ReservationsPage.test.jsx
+++ b/src/frontend/src/pages/ReservationsPage.test.jsx
@@ -1,0 +1,158 @@
+import { render, screen, fireEvent, waitFor } from '@testing-library/react'
+import { MemoryRouter } from 'react-router-dom'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import ReservationsPage from './ReservationsPage'
+
+vi.mock('../api/reservationsApi', () => ({ cancelReservation: vi.fn() }))
+
+import { cancelReservation } from '../api/reservationsApi'
+
+const sampleEvents = [
+  { id: 1, title: 'Rock Concert', location: 'Montreal', date: '2025-08-01' },
+  { id: 2, title: 'Art Exhibition', location: 'Toronto', date: '2025-09-15' },
+]
+
+const sampleReservations = [
+  { id: 101, eventId: 1, status: 'CONFIRMED', createdAt: '2025-07-01T12:00:00Z' },
+  { id: 102, eventId: 2, status: 'CANCELLED', createdAt: '2025-07-02T12:00:00Z' },
+]
+
+function renderPage(props = {}) {
+  return render(
+    <MemoryRouter>
+      <ReservationsPage
+        events={props.events ?? sampleEvents}
+        reservations={props.reservations ?? sampleReservations}
+        reservationsLoading={props.reservationsLoading ?? false}
+        reservationsError={props.reservationsError ?? null}
+      />
+    </MemoryRouter>
+  )
+}
+
+describe('ReservationsPage — rendering', () => {
+  it('renders the page title', () => {
+    renderPage()
+    expect(screen.getByText('My Tickets')).toBeInTheDocument()
+  })
+
+  it('shows active reservation count', () => {
+    renderPage()
+    expect(screen.getByText('1 active')).toBeInTheDocument()
+  })
+
+  it('shows loading state', () => {
+    renderPage({ reservations: [], reservationsLoading: true })
+    expect(screen.getByText('Loading reservations…')).toBeInTheDocument()
+  })
+
+  it('shows error message with role="alert" when reservationsError is set', () => {
+    renderPage({ reservations: [], reservationsError: 'Network error' })
+    expect(screen.getByRole('alert')).toHaveTextContent('Network error')
+  })
+
+  it('shows empty state with browse link when no reservations', () => {
+    renderPage({ reservations: [] })
+    expect(screen.getByText(/No reservations yet/)).toBeInTheDocument()
+    expect(screen.getByRole('link', { name: /Browse events/i })).toBeInTheDocument()
+  })
+
+  it('renders event titles for each reservation', () => {
+    renderPage()
+    expect(screen.getByText('Rock Concert')).toBeInTheDocument()
+    expect(screen.getByText('Art Exhibition')).toBeInTheDocument()
+  })
+
+  it('renders the venue for each reservation', () => {
+    renderPage()
+    expect(screen.getByText('Montreal')).toBeInTheDocument()
+    expect(screen.getByText('Toronto')).toBeInTheDocument()
+  })
+
+  it('shows CONFIRMED status badge', () => {
+    renderPage()
+    expect(screen.getByText('CONFIRMED')).toBeInTheDocument()
+  })
+
+  it('shows CANCELLED status badge', () => {
+    renderPage()
+    expect(screen.getByText('CANCELLED')).toBeInTheDocument()
+  })
+
+  it('shows Cancel button only for CONFIRMED reservations', () => {
+    renderPage()
+    expect(screen.getAllByRole('button', { name: 'Cancel' }).length).toBe(1)
+  })
+
+  it('does not show Cancel button for CANCELLED reservations', () => {
+    renderPage({ reservations: [{ id: 102, eventId: 2, status: 'CANCELLED', createdAt: '2025-07-02T12:00:00Z' }] })
+    expect(screen.queryByRole('button', { name: 'Cancel' })).not.toBeInTheDocument()
+  })
+
+  it('shows "Unknown Event" when event id does not match any event', () => {
+    renderPage({
+      events: [],
+      reservations: [{ id: 101, eventId: 999, status: 'CONFIRMED', createdAt: '2025-07-01T12:00:00Z' }],
+    })
+    expect(screen.getByText('Unknown Event')).toBeInTheDocument()
+  })
+})
+
+describe('ReservationsPage — cancel flow', () => {
+  beforeEach(() => {
+    cancelReservation.mockReset()
+  })
+
+  it('shows confirmation prompt when Cancel is clicked', () => {
+    renderPage()
+    fireEvent.click(screen.getByRole('button', { name: 'Cancel' }))
+    expect(screen.getByText('Cancel this reservation?')).toBeInTheDocument()
+  })
+
+  it('hides the Cancel button and shows Yes/Keep options after clicking Cancel', () => {
+    renderPage()
+    fireEvent.click(screen.getByRole('button', { name: 'Cancel' }))
+    expect(screen.getByRole('button', { name: 'Yes, cancel' })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Keep it' })).toBeInTheDocument()
+  })
+
+  it('calls cancelReservation with the correct id when confirmed', async () => {
+    cancelReservation.mockResolvedValue(undefined)
+    renderPage()
+    fireEvent.click(screen.getByRole('button', { name: 'Cancel' }))
+    fireEvent.click(screen.getByRole('button', { name: 'Yes, cancel' }))
+    await waitFor(() => {
+      expect(cancelReservation).toHaveBeenCalledWith(101)
+    })
+  })
+
+  it('updates the reservation status to CANCELLED locally after confirmation', async () => {
+    cancelReservation.mockResolvedValue(undefined)
+    renderPage()
+    fireEvent.click(screen.getByRole('button', { name: 'Cancel' }))
+    fireEvent.click(screen.getByRole('button', { name: 'Yes, cancel' }))
+    await waitFor(() => {
+      expect(screen.getAllByText('CANCELLED').length).toBe(2)
+    })
+  })
+
+  it('dismisses the confirmation when Keep it is clicked', () => {
+    renderPage()
+    fireEvent.click(screen.getByRole('button', { name: 'Cancel' }))
+    fireEvent.click(screen.getByRole('button', { name: 'Keep it' }))
+    expect(screen.queryByText('Cancel this reservation?')).not.toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Cancel' })).toBeInTheDocument()
+  })
+
+  it('shows alert when cancellation fails', async () => {
+    cancelReservation.mockRejectedValue(new Error('Cancellation failed'))
+    const alertSpy = vi.spyOn(window, 'alert').mockImplementation(() => {})
+    renderPage()
+    fireEvent.click(screen.getByRole('button', { name: 'Cancel' }))
+    fireEvent.click(screen.getByRole('button', { name: 'Yes, cancel' }))
+    await waitFor(() => {
+      expect(alertSpy).toHaveBeenCalledWith('Failed to cancel reservation. Please try again.')
+    })
+    alertSpy.mockRestore()
+  })
+})


### PR DESCRIPTION
**Summary**

- Added **71 unit tests** across 4 new test files covering routing, form interactions, and UI page components
- All previously untested frontend pages now have full unit test coverage

---

**What was tested**

| File | Tests |
|------|-------|
| `src/App.test.jsx` | Route redirects for unauthenticated, USER, and ADMIN roles |
| `src/pages/AddEventsPage.test.jsx` | Form rendering, field interaction, submit success/error, loading state |
| `src/pages/EditEventsPage.test.jsx` | Event selection, form pre-fill, save changes, cancel event flow |
| `src/pages/ReservationsPage.test.jsx` | Reservation list rendering, status badges, cancel confirmation flow |

---

**Results**
<img width="1283" height="573" alt="image" src="https://github.com/user-attachments/assets/227e6d63-51e9-4c1d-8e3a-55d075b9f0d7" />
