### PR TITLE
Create backend unit tests

### DIFF
--- a/src/backend/src/test/java/com/letsgettesty/backend/auth/AuthExceptionHandlerTest.java
+++ b/src/backend/src/test/java/com/letsgettesty/backend/auth/AuthExceptionHandlerTest.java
@@ -1,0 +1,67 @@
+package com.letsgettesty.backend.auth;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.server.ResponseStatusException;
+
+class AuthExceptionHandlerTest {
+
+    private final AuthExceptionHandler handler = new AuthExceptionHandler();
+
+    @Test
+    void handleResponseStatusExceptionReturnsCorrectStatusAndMessage() {
+        ResponseStatusException exception = new ResponseStatusException(HttpStatus.UNAUTHORIZED, "Invalid bearer token.");
+
+        ResponseEntity<ApiErrorResponse> response = handler.handleResponseStatusException(exception);
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.UNAUTHORIZED);
+        assertThat(response.getBody()).isNotNull();
+        assertThat(response.getBody().message()).isEqualTo("Invalid bearer token.");
+    }
+
+    @Test
+    void handleResponseStatusExceptionUsesFallbackMessageWhenReasonIsNull() {
+        ResponseStatusException exception = new ResponseStatusException(HttpStatus.BAD_REQUEST);
+
+        ResponseEntity<ApiErrorResponse> response = handler.handleResponseStatusException(exception);
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.BAD_REQUEST);
+        assertThat(response.getBody()).isNotNull();
+        assertThat(response.getBody().message()).isEqualTo("Request failed.");
+    }
+
+    @Test
+    void handleResponseStatusExceptionReturnsForbiddenStatusAndMessage() {
+        ResponseStatusException exception = new ResponseStatusException(
+                HttpStatus.FORBIDDEN, "You do not have permission to access this resource.");
+
+        ResponseEntity<ApiErrorResponse> response = handler.handleResponseStatusException(exception);
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.FORBIDDEN);
+        assertThat(response.getBody().message()).isEqualTo("You do not have permission to access this resource.");
+    }
+
+    @Test
+    void handleResponseStatusExceptionReturnsNotFoundStatusAndMessage() {
+        ResponseStatusException exception = new ResponseStatusException(HttpStatus.NOT_FOUND, "Event not found.");
+
+        ResponseEntity<ApiErrorResponse> response = handler.handleResponseStatusException(exception);
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.NOT_FOUND);
+        assertThat(response.getBody().message()).isEqualTo("Event not found.");
+    }
+
+    @Test
+    void handleResponseStatusExceptionReturnsConflictStatusAndMessage() {
+        ResponseStatusException exception = new ResponseStatusException(
+                HttpStatus.CONFLICT, "An account already exists with that email.");
+
+        ResponseEntity<ApiErrorResponse> response = handler.handleResponseStatusException(exception);
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.CONFLICT);
+        assertThat(response.getBody().message()).isEqualTo("An account already exists with that email.");
+    }
+}

--- a/src/backend/src/test/java/com/letsgettesty/backend/auth/AuthorizationServiceTest.java
+++ b/src/backend/src/test/java/com/letsgettesty/backend/auth/AuthorizationServiceTest.java
@@ -1,0 +1,142 @@
+package com.letsgettesty.backend.auth;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.catchThrowableOfType;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.server.ResponseStatusException;
+
+import jakarta.servlet.http.HttpServletRequest;
+
+class AuthorizationServiceTest {
+
+    private final AuthorizationService authorizationService = new AuthorizationService();
+    private final HttpServletRequest request = mock(HttpServletRequest.class);
+
+    @Test
+    void requireAuthenticatedAccountReturnsAccountWhenPresent() {
+        AuthenticatedAccount account = new AuthenticatedAccount(1, AccountRole.USER, "Jane");
+        when(request.getAttribute(AuthorizationService.AUTHENTICATED_ACCOUNT_ATTRIBUTE)).thenReturn(account);
+
+        AuthenticatedAccount result = authorizationService.requireAuthenticatedAccount(request);
+
+        assertThat(result).isEqualTo(account);
+    }
+
+    @Test
+    void requireAuthenticatedAccountThrowsUnauthorizedWhenMissing() {
+        when(request.getAttribute(AuthorizationService.AUTHENTICATED_ACCOUNT_ATTRIBUTE)).thenReturn(null);
+
+        ResponseStatusException ex = catchThrowableOfType(
+                () -> authorizationService.requireAuthenticatedAccount(request),
+                ResponseStatusException.class);
+
+        assertThat(ex.getStatusCode()).isEqualTo(HttpStatus.UNAUTHORIZED);
+        assertThat(ex.getReason()).isEqualTo("Missing authenticated account.");
+    }
+
+    @Test
+    void requireAuthenticatedAccountThrowsUnauthorizedWhenWrongType() {
+        when(request.getAttribute(AuthorizationService.AUTHENTICATED_ACCOUNT_ATTRIBUTE)).thenReturn("not-an-account");
+
+        ResponseStatusException ex = catchThrowableOfType(
+                () -> authorizationService.requireAuthenticatedAccount(request),
+                ResponseStatusException.class);
+
+        assertThat(ex.getStatusCode()).isEqualTo(HttpStatus.UNAUTHORIZED);
+    }
+
+    @Test
+    void requireRoleReturnsAccountWhenRoleMatches() {
+        AuthenticatedAccount account = new AuthenticatedAccount(1, AccountRole.ADMIN, "Admin One");
+        when(request.getAttribute(AuthorizationService.AUTHENTICATED_ACCOUNT_ATTRIBUTE)).thenReturn(account);
+
+        AuthenticatedAccount result = authorizationService.requireRole(request, AccountRole.ADMIN);
+
+        assertThat(result).isEqualTo(account);
+    }
+
+    @Test
+    void requireRoleThrowsForbiddenWhenRoleMismatch() {
+        AuthenticatedAccount account = new AuthenticatedAccount(1, AccountRole.USER, "User One");
+        when(request.getAttribute(AuthorizationService.AUTHENTICATED_ACCOUNT_ATTRIBUTE)).thenReturn(account);
+
+        ResponseStatusException ex = catchThrowableOfType(
+                () -> authorizationService.requireRole(request, AccountRole.ADMIN),
+                ResponseStatusException.class);
+
+        assertThat(ex.getStatusCode()).isEqualTo(HttpStatus.FORBIDDEN);
+        assertThat(ex.getReason()).isEqualTo("You do not have permission to access this resource.");
+    }
+
+    @Test
+    void requireAnyRoleReturnsAccountWhenRoleIsInList() {
+        AuthenticatedAccount account = new AuthenticatedAccount(2, AccountRole.USER, "User One");
+        when(request.getAttribute(AuthorizationService.AUTHENTICATED_ACCOUNT_ATTRIBUTE)).thenReturn(account);
+
+        AuthenticatedAccount result = authorizationService.requireAnyRole(request, AccountRole.USER, AccountRole.ADMIN);
+
+        assertThat(result).isEqualTo(account);
+    }
+
+    @Test
+    void requireAnyRoleReturnsAccountWhenAdminIsInList() {
+        AuthenticatedAccount account = new AuthenticatedAccount(1, AccountRole.ADMIN, "Admin One");
+        when(request.getAttribute(AuthorizationService.AUTHENTICATED_ACCOUNT_ATTRIBUTE)).thenReturn(account);
+
+        AuthenticatedAccount result = authorizationService.requireAnyRole(request, AccountRole.USER, AccountRole.ADMIN);
+
+        assertThat(result).isEqualTo(account);
+    }
+
+    @Test
+    void requireAnyRoleThrowsForbiddenWhenRoleNotInList() {
+        AuthenticatedAccount account = new AuthenticatedAccount(2, AccountRole.USER, "User One");
+        when(request.getAttribute(AuthorizationService.AUTHENTICATED_ACCOUNT_ATTRIBUTE)).thenReturn(account);
+
+        ResponseStatusException ex = catchThrowableOfType(
+                () -> authorizationService.requireAnyRole(request, AccountRole.ADMIN),
+                ResponseStatusException.class);
+
+        assertThat(ex.getStatusCode()).isEqualTo(HttpStatus.FORBIDDEN);
+        assertThat(ex.getReason()).isEqualTo("You do not have permission to access this resource.");
+    }
+
+    @Test
+    void requireUserOwnershipReturnsAccountWhenUserIdMatches() {
+        AuthenticatedAccount account = new AuthenticatedAccount(7, AccountRole.USER, "User Seven");
+        when(request.getAttribute(AuthorizationService.AUTHENTICATED_ACCOUNT_ATTRIBUTE)).thenReturn(account);
+
+        AuthenticatedAccount result = authorizationService.requireUserOwnership(request, 7);
+
+        assertThat(result).isEqualTo(account);
+    }
+
+    @Test
+    void requireUserOwnershipThrowsForbiddenWhenUserIdMismatch() {
+        AuthenticatedAccount account = new AuthenticatedAccount(7, AccountRole.USER, "User Seven");
+        when(request.getAttribute(AuthorizationService.AUTHENTICATED_ACCOUNT_ATTRIBUTE)).thenReturn(account);
+
+        ResponseStatusException ex = catchThrowableOfType(
+                () -> authorizationService.requireUserOwnership(request, 99),
+                ResponseStatusException.class);
+
+        assertThat(ex.getStatusCode()).isEqualTo(HttpStatus.FORBIDDEN);
+        assertThat(ex.getReason()).isEqualTo("You can only access your own reservations.");
+    }
+
+    @Test
+    void requireUserOwnershipThrowsForbiddenWhenAccountIsAdmin() {
+        AuthenticatedAccount account = new AuthenticatedAccount(1, AccountRole.ADMIN, "Admin One");
+        when(request.getAttribute(AuthorizationService.AUTHENTICATED_ACCOUNT_ATTRIBUTE)).thenReturn(account);
+
+        ResponseStatusException ex = catchThrowableOfType(
+                () -> authorizationService.requireUserOwnership(request, 1),
+                ResponseStatusException.class);
+
+        assertThat(ex.getStatusCode()).isEqualTo(HttpStatus.FORBIDDEN);
+    }
+}

--- a/src/backend/src/test/java/com/letsgettesty/backend/auth/JdbcAuthRepositoryTest.java
+++ b/src/backend/src/test/java/com/letsgettesty/backend/auth/JdbcAuthRepositoryTest.java
@@ -1,0 +1,158 @@
+package com.letsgettesty.backend.auth;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.jdbc.core.RowMapper;
+
+class JdbcAuthRepositoryTest {
+
+    private final JdbcTemplate jdbcTemplate = mock(JdbcTemplate.class);
+    private final JdbcAuthRepository repository = new JdbcAuthRepository(jdbcTemplate);
+
+    // --- existsByFullName ---
+
+    @Test
+    void existsByFullNameReturnsTrueWhenCountIsPositive() {
+        when(jdbcTemplate.queryForObject(anyString(), eq(Integer.class), eq("Jane"), eq("Jane"))).thenReturn(1);
+
+        assertThat(repository.existsByFullName("Jane")).isTrue();
+    }
+
+    @Test
+    void existsByFullNameReturnsFalseWhenCountIsZero() {
+        when(jdbcTemplate.queryForObject(anyString(), eq(Integer.class), eq("Jane"), eq("Jane"))).thenReturn(0);
+
+        assertThat(repository.existsByFullName("Jane")).isFalse();
+    }
+
+    @Test
+    void existsByFullNameReturnsFalseWhenNullReturned() {
+        when(jdbcTemplate.queryForObject(anyString(), eq(Integer.class), eq("Jane"), eq("Jane"))).thenReturn(null);
+
+        assertThat(repository.existsByFullName("Jane")).isFalse();
+    }
+
+    // --- existsByEmail ---
+
+    @Test
+    void existsByEmailReturnsTrueWhenCountIsPositive() {
+        when(jdbcTemplate.queryForObject(anyString(), eq(Integer.class), eq("a@b.com"), eq("a@b.com"))).thenReturn(2);
+
+        assertThat(repository.existsByEmail("a@b.com")).isTrue();
+    }
+
+    @Test
+    void existsByEmailReturnsFalseWhenCountIsZero() {
+        when(jdbcTemplate.queryForObject(anyString(), eq(Integer.class), eq("a@b.com"), eq("a@b.com"))).thenReturn(0);
+
+        assertThat(repository.existsByEmail("a@b.com")).isFalse();
+    }
+
+    // --- existsByPhone ---
+
+    @Test
+    void existsByPhoneReturnsTrueWhenCountIsPositive() {
+        when(jdbcTemplate.queryForObject(anyString(), eq(Integer.class), eq("514-555-0100"), eq("514-555-0100")))
+                .thenReturn(1);
+
+        assertThat(repository.existsByPhone("514-555-0100")).isTrue();
+    }
+
+    @Test
+    void existsByPhoneReturnsFalseWhenCountIsZero() {
+        when(jdbcTemplate.queryForObject(anyString(), eq(Integer.class), eq("514-555-0100"), eq("514-555-0100")))
+                .thenReturn(0);
+
+        assertThat(repository.existsByPhone("514-555-0100")).isFalse();
+    }
+
+    // --- findUsersByLoginContact ---
+
+    @Test
+    void findUsersByLoginContactReturnsMatchingAccounts() {
+        AccountRecord account = new AccountRecord(1, AccountRole.USER, "Jane", "secret", "jane@example.com", null);
+        when(jdbcTemplate.query(anyString(), any(RowMapper.class), eq("jane@example.com"), eq("jane@example.com")))
+                .thenReturn(List.of(account));
+
+        List<AccountRecord> result = repository.findUsersByLoginContact("jane@example.com");
+
+        assertThat(result).hasSize(1);
+        assertThat(result.get(0).email()).isEqualTo("jane@example.com");
+        assertThat(result.get(0).role()).isEqualTo(AccountRole.USER);
+    }
+
+    @Test
+    void findUsersByLoginContactReturnsEmptyWhenNoMatch() {
+        when(jdbcTemplate.query(anyString(), any(RowMapper.class), eq("unknown@example.com"), eq("unknown@example.com")))
+                .thenReturn(List.of());
+
+        List<AccountRecord> result = repository.findUsersByLoginContact("unknown@example.com");
+
+        assertThat(result).isEmpty();
+    }
+
+    // --- findAdminsByLoginContact ---
+
+    @Test
+    void findAdminsByLoginContactReturnsMatchingAccounts() {
+        AccountRecord account = new AccountRecord(2, AccountRole.ADMIN, "Admin One", "secret", null, "514-555-0100");
+        when(jdbcTemplate.query(anyString(), any(RowMapper.class), eq("514-555-0100"), eq("514-555-0100")))
+                .thenReturn(List.of(account));
+
+        List<AccountRecord> result = repository.findAdminsByLoginContact("514-555-0100");
+
+        assertThat(result).hasSize(1);
+        assertThat(result.get(0).role()).isEqualTo(AccountRole.ADMIN);
+        assertThat(result.get(0).phone()).isEqualTo("514-555-0100");
+    }
+
+    @Test
+    void findAdminsByLoginContactReturnsEmptyWhenNoMatch() {
+        when(jdbcTemplate.query(anyString(), any(RowMapper.class), eq("nobody@example.com"), eq("nobody@example.com")))
+                .thenReturn(List.of());
+
+        List<AccountRecord> result = repository.findAdminsByLoginContact("nobody@example.com");
+
+        assertThat(result).isEmpty();
+    }
+
+    // --- createAccount ---
+
+    @Test
+    void createAccountReturnsCreatedUserAccount() {
+        AccountRecord created = new AccountRecord(10, AccountRole.USER, "New User", "hashed", "new@example.com", null);
+        when(jdbcTemplate.queryForObject(anyString(), any(RowMapper.class),
+                eq("New User"), eq("hashed"), eq("new@example.com"), eq((String) null)))
+                .thenReturn(created);
+
+        AccountRecord result = repository.createAccount(
+                AccountRole.USER, "New User", "hashed", "new@example.com", null);
+
+        assertThat(result.id()).isEqualTo(10);
+        assertThat(result.role()).isEqualTo(AccountRole.USER);
+        assertThat(result.fullName()).isEqualTo("New User");
+    }
+
+    @Test
+    void createAccountReturnsCreatedAdminAccount() {
+        AccountRecord created = new AccountRecord(11, AccountRole.ADMIN, "Admin Two", "hashed", null, "514-000-0001");
+        when(jdbcTemplate.queryForObject(anyString(), any(RowMapper.class),
+                eq("Admin Two"), eq("hashed"), eq((String) null), eq("514-000-0001")))
+                .thenReturn(created);
+
+        AccountRecord result = repository.createAccount(
+                AccountRole.ADMIN, "Admin Two", "hashed", null, "514-000-0001");
+
+        assertThat(result.id()).isEqualTo(11);
+        assertThat(result.role()).isEqualTo(AccountRole.ADMIN);
+    }
+}

--- a/src/backend/src/test/java/com/letsgettesty/backend/auth/JwtAuthInterceptorTest.java
+++ b/src/backend/src/test/java/com/letsgettesty/backend/auth/JwtAuthInterceptorTest.java
@@ -1,0 +1,98 @@
+package com.letsgettesty.backend.auth;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.catchThrowableOfType;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.server.ResponseStatusException;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+
+class JwtAuthInterceptorTest {
+
+    private final JwtService jwtService = mock(JwtService.class);
+    private final JwtAuthInterceptor interceptor = new JwtAuthInterceptor(jwtService);
+    private final HttpServletRequest request = mock(HttpServletRequest.class);
+    private final HttpServletResponse response = mock(HttpServletResponse.class);
+
+    @Test
+    void preHandleReturnsTrueForOptionsRequest() throws Exception {
+        when(request.getMethod()).thenReturn("OPTIONS");
+
+        boolean result = interceptor.preHandle(request, response, new Object());
+
+        assertThat(result).isTrue();
+    }
+
+    @Test
+    void preHandleThrowsUnauthorizedWhenAuthorizationHeaderIsMissing() {
+        when(request.getMethod()).thenReturn("GET");
+        when(request.getHeader("Authorization")).thenReturn(null);
+
+        ResponseStatusException ex = catchThrowableOfType(
+                () -> interceptor.preHandle(request, response, new Object()),
+                ResponseStatusException.class);
+
+        assertThat(ex.getStatusCode()).isEqualTo(HttpStatus.UNAUTHORIZED);
+        assertThat(ex.getReason()).isEqualTo("Missing bearer token.");
+    }
+
+    @Test
+    void preHandleThrowsUnauthorizedWhenHeaderDoesNotStartWithBearer() {
+        when(request.getMethod()).thenReturn("POST");
+        when(request.getHeader("Authorization")).thenReturn("Basic dXNlcjpwYXNz");
+
+        ResponseStatusException ex = catchThrowableOfType(
+                () -> interceptor.preHandle(request, response, new Object()),
+                ResponseStatusException.class);
+
+        assertThat(ex.getStatusCode()).isEqualTo(HttpStatus.UNAUTHORIZED);
+        assertThat(ex.getReason()).isEqualTo("Missing bearer token.");
+    }
+
+    @Test
+    void preHandleSetsAuthenticatedAccountAttributeOnSuccess() throws Exception {
+        AuthenticatedAccount account = new AuthenticatedAccount(1, AccountRole.USER, "Jane");
+        when(request.getMethod()).thenReturn("GET");
+        when(request.getHeader("Authorization")).thenReturn("Bearer valid-token");
+        when(jwtService.authenticate("valid-token")).thenReturn(account);
+
+        boolean result = interceptor.preHandle(request, response, new Object());
+
+        assertThat(result).isTrue();
+        verify(request).setAttribute(AuthorizationService.AUTHENTICATED_ACCOUNT_ATTRIBUTE, account);
+    }
+
+    @Test
+    void preHandleStripsWhitespaceFromTokenBeforeAuthenticating() throws Exception {
+        AuthenticatedAccount account = new AuthenticatedAccount(2, AccountRole.ADMIN, "Admin");
+        when(request.getMethod()).thenReturn("GET");
+        when(request.getHeader("Authorization")).thenReturn("Bearer   spaced-token  ");
+        when(jwtService.authenticate("spaced-token")).thenReturn(account);
+
+        boolean result = interceptor.preHandle(request, response, new Object());
+
+        assertThat(result).isTrue();
+        verify(jwtService).authenticate("spaced-token");
+    }
+
+    @Test
+    void preHandleThrowsWhenJwtServiceThrows() {
+        when(request.getMethod()).thenReturn("DELETE");
+        when(request.getHeader("Authorization")).thenReturn("Bearer bad-token");
+        when(jwtService.authenticate("bad-token"))
+                .thenThrow(new ResponseStatusException(HttpStatus.UNAUTHORIZED, "Invalid bearer token."));
+
+        ResponseStatusException ex = catchThrowableOfType(
+                () -> interceptor.preHandle(request, response, new Object()),
+                ResponseStatusException.class);
+
+        assertThat(ex.getStatusCode()).isEqualTo(HttpStatus.UNAUTHORIZED);
+        assertThat(ex.getReason()).isEqualTo("Invalid bearer token.");
+    }
+}

--- a/src/backend/src/test/java/com/letsgettesty/backend/auth/JwtServiceTest.java
+++ b/src/backend/src/test/java/com/letsgettesty/backend/auth/JwtServiceTest.java
@@ -1,0 +1,110 @@
+package com.letsgettesty.backend.auth;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.catchThrowableOfType;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.server.ResponseStatusException;
+
+class JwtServiceTest {
+
+    private final JwtService jwtService = new JwtService(new ObjectMapper(), "test-secret-key-for-unit-tests", 86400);
+
+    @Test
+    void generateTokenProducesThreeSegmentJwt() {
+        AccountRecord account = new AccountRecord(1, AccountRole.USER, "Jane Doe", "secret", "jane@example.com", null);
+
+        String token = jwtService.generateToken(account);
+
+        assertThat(token.split("\\.")).hasSize(3);
+    }
+
+    @Test
+    void authenticateReturnsCorrectAccountFromValidToken() {
+        AccountRecord account = new AccountRecord(5, AccountRole.ADMIN, "Admin One", "secret", null, "514-555-0100");
+        String token = jwtService.generateToken(account);
+
+        AuthenticatedAccount result = jwtService.authenticate(token);
+
+        assertThat(result.id()).isEqualTo(5);
+        assertThat(result.role()).isEqualTo(AccountRole.ADMIN);
+        assertThat(result.fullName()).isEqualTo("Admin One");
+    }
+
+    @Test
+    void authenticateThrowsUnauthorizedForNullToken() {
+        ResponseStatusException ex = catchThrowableOfType(
+                () -> jwtService.authenticate(null),
+                ResponseStatusException.class);
+
+        assertThat(ex.getStatusCode()).isEqualTo(HttpStatus.UNAUTHORIZED);
+        assertThat(ex.getReason()).isEqualTo("Invalid bearer token.");
+    }
+
+    @Test
+    void authenticateThrowsUnauthorizedForBlankToken() {
+        ResponseStatusException ex = catchThrowableOfType(
+                () -> jwtService.authenticate("   "),
+                ResponseStatusException.class);
+
+        assertThat(ex.getStatusCode()).isEqualTo(HttpStatus.UNAUTHORIZED);
+    }
+
+    @Test
+    void authenticateThrowsUnauthorizedForTokenWithWrongSegmentCount() {
+        ResponseStatusException ex = catchThrowableOfType(
+                () -> jwtService.authenticate("abc.def"),
+                ResponseStatusException.class);
+
+        assertThat(ex.getStatusCode()).isEqualTo(HttpStatus.UNAUTHORIZED);
+    }
+
+    @Test
+    void authenticateThrowsUnauthorizedForTamperedSignature() {
+        AccountRecord account = new AccountRecord(1, AccountRole.USER, "User", "secret", "u@example.com", null);
+        String token = jwtService.generateToken(account);
+        String tampered = token.substring(0, token.lastIndexOf('.') + 1) + "tampered-signature";
+
+        ResponseStatusException ex = catchThrowableOfType(
+                () -> jwtService.authenticate(tampered),
+                ResponseStatusException.class);
+
+        assertThat(ex.getStatusCode()).isEqualTo(HttpStatus.UNAUTHORIZED);
+    }
+
+    @Test
+    void authenticateThrowsUnauthorizedForExpiredToken() {
+        JwtService shortLived = new JwtService(new ObjectMapper(), "test-secret-key-for-unit-tests", -1);
+        AccountRecord account = new AccountRecord(1, AccountRole.USER, "User", "secret", "u@example.com", null);
+        String token = shortLived.generateToken(account);
+
+        ResponseStatusException ex = catchThrowableOfType(
+                () -> shortLived.authenticate(token),
+                ResponseStatusException.class);
+
+        assertThat(ex.getStatusCode()).isEqualTo(HttpStatus.UNAUTHORIZED);
+        assertThat(ex.getReason()).isEqualTo("Bearer token has expired.");
+    }
+
+    @Test
+    void verifyTokenDoesNotThrowForValidToken() {
+        AccountRecord account = new AccountRecord(2, AccountRole.USER, "Jane", "secret", "jane@example.com", null);
+        String token = jwtService.generateToken(account);
+
+        jwtService.verifyToken(token);
+    }
+
+    @Test
+    void generateAndAuthenticateRoundTripForUserRole() {
+        AccountRecord account = new AccountRecord(42, AccountRole.USER, "Regular User", "pw", "user@example.com", null);
+        String token = jwtService.generateToken(account);
+
+        AuthenticatedAccount result = jwtService.authenticate(token);
+
+        assertThat(result.id()).isEqualTo(42);
+        assertThat(result.role()).isEqualTo(AccountRole.USER);
+        assertThat(result.fullName()).isEqualTo("Regular User");
+    }
+}

--- a/src/backend/src/test/java/com/letsgettesty/backend/event/JdbcEventRepositoryTest.java
+++ b/src/backend/src/test/java/com/letsgettesty/backend/event/JdbcEventRepositoryTest.java
@@ -1,0 +1,137 @@
+package com.letsgettesty.backend.event;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.jdbc.core.RowMapper;
+
+import com.letsgettesty.backend.model.Event;
+import com.letsgettesty.backend.model.EventCategory;
+
+class JdbcEventRepositoryTest {
+
+    private final JdbcTemplate jdbcTemplate = mock(JdbcTemplate.class);
+    private final JdbcEventRepository repository = new JdbcEventRepository(jdbcTemplate);
+
+    private Event sampleEvent() {
+        return new Event(1, "Concert", "Desc", EventCategory.CONCERT, "Venue",
+                LocalDateTime.parse("2026-06-01T18:00:00"), null, 100, 20, 5, false);
+    }
+
+    // --- findAllOrderedByStartsAt ---
+
+    @Test
+    @SuppressWarnings("unchecked")
+    void findAllOrderedByStartsAtReturnsEvents() {
+        when(jdbcTemplate.query(anyString(), any(RowMapper.class))).thenReturn(List.of(sampleEvent()));
+
+        List<Event> result = repository.findAllOrderedByStartsAt();
+
+        assertThat(result).hasSize(1);
+        assertThat(result.get(0).getTitle()).isEqualTo("Concert");
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    void findAllOrderedByStartsAtReturnsEmptyList() {
+        when(jdbcTemplate.query(anyString(), any(RowMapper.class))).thenReturn(List.of());
+
+        List<Event> result = repository.findAllOrderedByStartsAt();
+
+        assertThat(result).isEmpty();
+    }
+
+    // --- findById ---
+
+    @Test
+    @SuppressWarnings("unchecked")
+    void findByIdReturnsEventWhenFound() {
+        when(jdbcTemplate.query(anyString(), any(RowMapper.class), eq(1))).thenReturn(List.of(sampleEvent()));
+
+        Optional<Event> result = repository.findById(1);
+
+        assertThat(result).isPresent();
+        assertThat(result.get().getId()).isEqualTo(1);
+        assertThat(result.get().getTitle()).isEqualTo("Concert");
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    void findByIdReturnsEmptyOptionalWhenNotFound() {
+        when(jdbcTemplate.query(anyString(), any(RowMapper.class), eq(999))).thenReturn(List.of());
+
+        Optional<Event> result = repository.findById(999);
+
+        assertThat(result).isEmpty();
+    }
+
+    // --- insert ---
+
+    @Test
+    @SuppressWarnings("unchecked")
+    void insertDelegatesToJdbcTemplateAndReturnsEvent() {
+        Event event = sampleEvent();
+        when(jdbcTemplate.queryForObject(anyString(), any(RowMapper.class),
+                any(), any(), any(), any(), any(), any(), any(), any(), any(), any()))
+                .thenReturn(event);
+
+        Event result = repository.insert(event);
+
+        assertThat(result).isEqualTo(event);
+        assertThat(result.getTitle()).isEqualTo("Concert");
+    }
+
+    // --- update ---
+
+    @Test
+    void updateReturnsTrueWhenRowIsUpdated() {
+        when(jdbcTemplate.update(anyString(),
+                any(), any(), any(), any(), any(), any(), any(), any(), any(), any()))
+                .thenReturn(1);
+
+        boolean result = repository.update(sampleEvent());
+
+        assertThat(result).isTrue();
+    }
+
+    @Test
+    void updateReturnsFalseWhenNoRowUpdated() {
+        when(jdbcTemplate.update(anyString(),
+                any(), any(), any(), any(), any(), any(), any(), any(), any(), any()))
+                .thenReturn(0);
+
+        boolean result = repository.update(sampleEvent());
+
+        assertThat(result).isFalse();
+    }
+
+    // --- setCancelled ---
+
+    @Test
+    void setCancelledReturnsTrueWhenRowIsUpdated() {
+        when(jdbcTemplate.update(anyString(), eq(true), eq(1))).thenReturn(1);
+
+        boolean result = repository.setCancelled(1, true);
+
+        assertThat(result).isTrue();
+    }
+
+    @Test
+    void setCancelledReturnsFalseWhenNoRowUpdated() {
+        when(jdbcTemplate.update(anyString(), eq(false), eq(999))).thenReturn(0);
+
+        boolean result = repository.setCancelled(999, false);
+
+        assertThat(result).isFalse();
+    }
+}

--- a/src/backend/src/test/java/com/letsgettesty/backend/notification/JdbcNotificationRepositoryTest.java
+++ b/src/backend/src/test/java/com/letsgettesty/backend/notification/JdbcNotificationRepositoryTest.java
@@ -85,27 +85,4 @@ class JdbcNotificationRepositoryTest {
         assertThat(result.getSubject()).isEqualTo("Event update");
     }
 
-    @Test
-    @SuppressWarnings("unchecked")
-    void insertWithSmsChannelUsesCorrectPersistenceValue() {
-        Notification input = new Notification(
-                0, 7, NotificationChannel.SMS, "514-555-0100",
-                null, "Your reservation is confirmed.", LocalDateTime.parse("2026-02-01T09:00:00"));
-        Notification saved = new Notification(
-                20, 7, NotificationChannel.SMS, "514-555-0100",
-                null, "Your reservation is confirmed.", LocalDateTime.parse("2026-02-01T09:00:00"));
-
-        when(jdbcTemplate.queryForObject(anyString(), any(RowMapper.class),
-                eq(7),
-                eq("sms"),
-                eq("514-555-0100"),
-                eq("Your reservation is confirmed."),
-                eq(LocalDateTime.parse("2026-02-01T09:00:00"))))
-                .thenReturn(saved);
-
-        Notification result = repository.insert(input);
-
-        assertThat(result.getId()).isEqualTo(20);
-        assertThat(result.getChannel()).isEqualTo(NotificationChannel.SMS);
-    }
 }

--- a/src/backend/src/test/java/com/letsgettesty/backend/notification/JdbcNotificationRepositoryTest.java
+++ b/src/backend/src/test/java/com/letsgettesty/backend/notification/JdbcNotificationRepositoryTest.java
@@ -1,0 +1,111 @@
+package com.letsgettesty.backend.notification;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.time.LocalDateTime;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.jdbc.core.RowMapper;
+
+import com.letsgettesty.backend.model.Notification;
+import com.letsgettesty.backend.model.NotificationChannel;
+
+class JdbcNotificationRepositoryTest {
+
+    private final JdbcTemplate jdbcTemplate = mock(JdbcTemplate.class);
+    private final JdbcNotificationRepository repository = new JdbcNotificationRepository(jdbcTemplate);
+
+    private Notification sampleNotification() {
+        return new Notification(
+                0,
+                5,
+                NotificationChannel.EMAIL,
+                "jane@example.com",
+                "Registration confirmed",
+                "You have been registered for Concert.",
+                LocalDateTime.parse("2026-01-01T10:00:00"));
+    }
+
+    // --- insert ---
+
+    @Test
+    @SuppressWarnings("unchecked")
+    void insertReturnsPersistedNotificationWithSubjectRestored() {
+        Notification input = sampleNotification();
+        Notification saved = new Notification(
+                99,
+                5,
+                NotificationChannel.EMAIL,
+                "jane@example.com",
+                null,
+                "You have been registered for Concert.",
+                LocalDateTime.parse("2026-01-01T10:00:00"));
+
+        when(jdbcTemplate.queryForObject(anyString(), any(RowMapper.class),
+                eq(5),
+                eq("email"),
+                eq("jane@example.com"),
+                eq("You have been registered for Concert."),
+                eq(LocalDateTime.parse("2026-01-01T10:00:00"))))
+                .thenReturn(saved);
+
+        Notification result = repository.insert(input);
+
+        assertThat(result).isNotNull();
+        assertThat(result.getId()).isEqualTo(99);
+        assertThat(result.getReservationId()).isEqualTo(5);
+        assertThat(result.getChannel()).isEqualTo(NotificationChannel.EMAIL);
+        assertThat(result.getDestination()).isEqualTo("jane@example.com");
+        assertThat(result.getMessage()).isEqualTo("You have been registered for Concert.");
+        assertThat(result.getSubject()).isEqualTo("Registration confirmed");
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    void insertRestoresSubjectFromInputWhenSavedHasNullSubject() {
+        Notification input = new Notification(
+                0, 3, NotificationChannel.EMAIL, "user@example.com",
+                "Event update", "Your event has been updated.", LocalDateTime.now());
+        Notification saved = new Notification(
+                10, 3, NotificationChannel.EMAIL, "user@example.com",
+                null, "Your event has been updated.", LocalDateTime.now());
+
+        when(jdbcTemplate.queryForObject(anyString(), any(RowMapper.class),
+                any(), any(), any(), any(), any()))
+                .thenReturn(saved);
+
+        Notification result = repository.insert(input);
+
+        assertThat(result.getSubject()).isEqualTo("Event update");
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    void insertWithSmsChannelUsesCorrectPersistenceValue() {
+        Notification input = new Notification(
+                0, 7, NotificationChannel.SMS, "514-555-0100",
+                null, "Your reservation is confirmed.", LocalDateTime.parse("2026-02-01T09:00:00"));
+        Notification saved = new Notification(
+                20, 7, NotificationChannel.SMS, "514-555-0100",
+                null, "Your reservation is confirmed.", LocalDateTime.parse("2026-02-01T09:00:00"));
+
+        when(jdbcTemplate.queryForObject(anyString(), any(RowMapper.class),
+                eq(7),
+                eq("sms"),
+                eq("514-555-0100"),
+                eq("Your reservation is confirmed."),
+                eq(LocalDateTime.parse("2026-02-01T09:00:00"))))
+                .thenReturn(saved);
+
+        Notification result = repository.insert(input);
+
+        assertThat(result.getId()).isEqualTo(20);
+        assertThat(result.getChannel()).isEqualTo(NotificationChannel.SMS);
+    }
+}

--- a/src/backend/src/test/java/com/letsgettesty/backend/reservation/JdbcReservationRepositoryTest.java
+++ b/src/backend/src/test/java/com/letsgettesty/backend/reservation/JdbcReservationRepositoryTest.java
@@ -1,0 +1,176 @@
+package com.letsgettesty.backend.reservation;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.jdbc.core.RowMapper;
+
+import com.letsgettesty.backend.model.Reservation;
+import com.letsgettesty.backend.model.ReservationStatus;
+
+class JdbcReservationRepositoryTest {
+
+    private final JdbcTemplate jdbcTemplate = mock(JdbcTemplate.class);
+    private final JdbcReservationRepository repository = new JdbcReservationRepository(jdbcTemplate);
+
+    private Reservation sampleReservation() {
+        return new Reservation(1, 2, 10, ReservationStatus.CONFIRMED,
+                LocalDateTime.parse("2026-01-01T10:00:00"), null);
+    }
+
+    // --- findAll ---
+
+    @Test
+    @SuppressWarnings("unchecked")
+    void findAllReturnsAllReservations() {
+        when(jdbcTemplate.query(anyString(), any(RowMapper.class))).thenReturn(List.of(sampleReservation()));
+
+        List<Reservation> result = repository.findAll();
+
+        assertThat(result).hasSize(1);
+        assertThat(result.get(0).getId()).isEqualTo(1);
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    void findAllReturnsEmptyList() {
+        when(jdbcTemplate.query(anyString(), any(RowMapper.class))).thenReturn(List.of());
+
+        List<Reservation> result = repository.findAll();
+
+        assertThat(result).isEmpty();
+    }
+
+    // --- findById ---
+
+    @Test
+    @SuppressWarnings("unchecked")
+    void findByIdReturnsReservationWhenFound() {
+        when(jdbcTemplate.query(anyString(), any(RowMapper.class), eq(1))).thenReturn(List.of(sampleReservation()));
+
+        Optional<Reservation> result = repository.findById(1);
+
+        assertThat(result).isPresent();
+        assertThat(result.get().getId()).isEqualTo(1);
+        assertThat(result.get().getStatus()).isEqualTo(ReservationStatus.CONFIRMED);
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    void findByIdReturnsEmptyOptionalWhenNotFound() {
+        when(jdbcTemplate.query(anyString(), any(RowMapper.class), eq(999))).thenReturn(List.of());
+
+        Optional<Reservation> result = repository.findById(999);
+
+        assertThat(result).isEmpty();
+    }
+
+    // --- findByUserId ---
+
+    @Test
+    @SuppressWarnings("unchecked")
+    void findByUserIdReturnsReservationsForUser() {
+        Reservation r1 = new Reservation(1, 2, 10, ReservationStatus.CONFIRMED,
+                LocalDateTime.parse("2026-01-01T10:00:00"), null);
+        Reservation r2 = new Reservation(2, 2, 11, ReservationStatus.CONFIRMED,
+                LocalDateTime.parse("2026-01-02T10:00:00"), null);
+        when(jdbcTemplate.query(anyString(), any(RowMapper.class), eq(2))).thenReturn(List.of(r1, r2));
+
+        List<Reservation> result = repository.findByUserId(2);
+
+        assertThat(result).hasSize(2);
+        assertThat(result).allMatch(r -> r.getUserId() == 2);
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    void findByUserIdReturnsEmptyWhenNoReservations() {
+        when(jdbcTemplate.query(anyString(), any(RowMapper.class), eq(99))).thenReturn(List.of());
+
+        List<Reservation> result = repository.findByUserId(99);
+
+        assertThat(result).isEmpty();
+    }
+
+    // --- findByEventId ---
+
+    @Test
+    @SuppressWarnings("unchecked")
+    void findByEventIdReturnsReservationsForEvent() {
+        when(jdbcTemplate.query(anyString(), any(RowMapper.class), eq(10))).thenReturn(List.of(sampleReservation()));
+
+        List<Reservation> result = repository.findByEventId(10);
+
+        assertThat(result).hasSize(1);
+        assertThat(result.get(0).getEventId()).isEqualTo(10);
+    }
+
+    // --- insert ---
+
+    @Test
+    @SuppressWarnings("unchecked")
+    void insertDelegatesToJdbcTemplateAndReturnsReservation() {
+        Reservation reservation = sampleReservation();
+        when(jdbcTemplate.queryForObject(anyString(), any(RowMapper.class), eq(2), eq(10)))
+                .thenReturn(reservation);
+
+        Reservation result = repository.insert(reservation);
+
+        assertThat(result.getUserId()).isEqualTo(2);
+        assertThat(result.getEventId()).isEqualTo(10);
+        assertThat(result.getStatus()).isEqualTo(ReservationStatus.CONFIRMED);
+    }
+
+    // --- setCancelled ---
+
+    @Test
+    void setCancelledReturnsTrueWhenRowIsUpdated() {
+        when(jdbcTemplate.update(anyString(), eq(1))).thenReturn(1);
+
+        boolean result = repository.setCancelled(1);
+
+        assertThat(result).isTrue();
+    }
+
+    @Test
+    void setCancelledReturnsFalseWhenNoRowUpdated() {
+        when(jdbcTemplate.update(anyString(), eq(999))).thenReturn(0);
+
+        boolean result = repository.setCancelled(999);
+
+        assertThat(result).isFalse();
+    }
+
+    // --- exists ---
+
+    @Test
+    @SuppressWarnings("unchecked")
+    void existsReturnsTrueWhenReservationFound() {
+        when(jdbcTemplate.query(anyString(), any(RowMapper.class), eq(2), eq(10)))
+                .thenReturn(List.of(sampleReservation()));
+
+        boolean result = repository.exists(2, 10);
+
+        assertThat(result).isTrue();
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    void existsReturnsFalseWhenNoReservationFound() {
+        when(jdbcTemplate.query(anyString(), any(RowMapper.class), eq(2), eq(10))).thenReturn(List.of());
+
+        boolean result = repository.exists(2, 10);
+
+        assertThat(result).isFalse();
+    }
+}

--- a/src/backend/src/test/java/com/letsgettesty/backend/reservation/ReservationControllerTest.java
+++ b/src/backend/src/test/java/com/letsgettesty/backend/reservation/ReservationControllerTest.java
@@ -1,0 +1,298 @@
+package com.letsgettesty.backend.reservation;
+
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasSize;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.when;
+import static org.springframework.http.MediaType.APPLICATION_JSON;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.web.server.ResponseStatusException;
+
+import com.letsgettesty.backend.auth.AccountRole;
+import com.letsgettesty.backend.auth.AuthenticatedAccount;
+import com.letsgettesty.backend.auth.AuthExceptionHandler;
+import com.letsgettesty.backend.auth.AuthorizationService;
+import com.letsgettesty.backend.auth.JwtAuthInterceptor;
+import com.letsgettesty.backend.auth.JwtService;
+import com.letsgettesty.backend.model.Reservation;
+import com.letsgettesty.backend.model.ReservationStatus;
+
+@WebMvcTest(ReservationController.class)
+@Import({ AuthExceptionHandler.class, JwtAuthInterceptor.class })
+class ReservationControllerTest {
+
+    private static final String ADMIN_TOKEN = "admin-token";
+    private static final String USER_TOKEN = "user-token";
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean
+    private ReservationService reservationService;
+
+    @MockBean
+    private JwtService jwtService;
+
+    @MockBean
+    private AuthorizationService authorizationService;
+
+    @BeforeEach
+    void setUp() {
+        when(jwtService.authenticate(ADMIN_TOKEN))
+                .thenReturn(new AuthenticatedAccount(1, AccountRole.ADMIN, "Admin One"));
+        when(jwtService.authenticate(USER_TOKEN))
+                .thenReturn(new AuthenticatedAccount(2, AccountRole.USER, "User One"));
+    }
+
+    private Reservation reservation(int id, int userId) {
+        return new Reservation(id, userId, 10, ReservationStatus.CONFIRMED,
+                LocalDateTime.parse("2026-01-01T10:00:00"), null);
+    }
+
+    // --- GET /api/reservations ---
+
+    @Test
+    void listReservationsRequiresBearerToken() throws Exception {
+        mockMvc.perform(get("/api/reservations"))
+                .andExpect(status().isUnauthorized())
+                .andExpect(jsonPath("$.message", equalTo("Missing bearer token.")));
+    }
+
+    @Test
+    void listReservationsReturnsListForAdmin() throws Exception {
+        when(authorizationService.requireRole(any(), eq(AccountRole.ADMIN)))
+                .thenReturn(new AuthenticatedAccount(1, AccountRole.ADMIN, "Admin One"));
+        when(reservationService.listReservations()).thenReturn(List.of(reservation(1, 2), reservation(2, 3)));
+
+        mockMvc.perform(get("/api/reservations")
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + ADMIN_TOKEN))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$", hasSize(2)))
+                .andExpect(jsonPath("$[0].id").value(1));
+    }
+
+    @Test
+    void listReservationsForbidsRegularUser() throws Exception {
+        when(authorizationService.requireRole(any(), eq(AccountRole.ADMIN)))
+                .thenThrow(new ResponseStatusException(HttpStatus.FORBIDDEN,
+                        "You do not have permission to access this resource."));
+
+        mockMvc.perform(get("/api/reservations")
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + USER_TOKEN))
+                .andExpect(status().isForbidden())
+                .andExpect(jsonPath("$.message", equalTo("You do not have permission to access this resource.")));
+    }
+
+    // --- GET /api/reservations/{id} ---
+
+    @Test
+    void getReservationReturnsReservationForOwner() throws Exception {
+        Reservation r = reservation(5, 2);
+        when(authorizationService.requireAnyRole(any(), eq(AccountRole.USER), eq(AccountRole.ADMIN)))
+                .thenReturn(new AuthenticatedAccount(2, AccountRole.USER, "User One"));
+        when(reservationService.getReservation(5)).thenReturn(r);
+
+        mockMvc.perform(get("/api/reservations/5")
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + USER_TOKEN))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.id").value(5))
+                .andExpect(jsonPath("$.status").value("CONFIRMED"))
+                .andExpect(jsonPath("$.userId").value(2));
+    }
+
+    @Test
+    void getReservationReturnsNotFoundWhenMissing() throws Exception {
+        when(authorizationService.requireAnyRole(any(), eq(AccountRole.USER), eq(AccountRole.ADMIN)))
+                .thenReturn(new AuthenticatedAccount(2, AccountRole.USER, "User One"));
+        when(reservationService.getReservation(999))
+                .thenThrow(new ResponseStatusException(HttpStatus.NOT_FOUND, "Reservation not found."));
+
+        mockMvc.perform(get("/api/reservations/999")
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + USER_TOKEN))
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.message", equalTo("Reservation not found.")));
+    }
+
+    @Test
+    void getReservationForbidsUserAccessingOtherUsersReservation() throws Exception {
+        Reservation r = reservation(5, 99);
+        when(authorizationService.requireAnyRole(any(), eq(AccountRole.USER), eq(AccountRole.ADMIN)))
+                .thenReturn(new AuthenticatedAccount(2, AccountRole.USER, "User One"));
+        when(reservationService.getReservation(5)).thenReturn(r);
+        when(authorizationService.requireUserOwnership(any(), eq(99)))
+                .thenThrow(new ResponseStatusException(HttpStatus.FORBIDDEN,
+                        "You can only access your own reservations."));
+
+        mockMvc.perform(get("/api/reservations/5")
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + USER_TOKEN))
+                .andExpect(status().isForbidden())
+                .andExpect(jsonPath("$.message", equalTo("You can only access your own reservations.")));
+    }
+
+    // --- GET /api/reservations/user/{userId} ---
+
+    @Test
+    void listByUserReturnsReservationsForOwner() throws Exception {
+        when(authorizationService.requireUserOwnership(any(), eq(2)))
+                .thenReturn(new AuthenticatedAccount(2, AccountRole.USER, "User One"));
+        when(reservationService.listByUser(2)).thenReturn(List.of(reservation(3, 2)));
+
+        mockMvc.perform(get("/api/reservations/user/2")
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + USER_TOKEN))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$", hasSize(1)))
+                .andExpect(jsonPath("$[0].userId").value(2));
+    }
+
+    @Test
+    void listByUserForbidsOtherUsers() throws Exception {
+        when(authorizationService.requireUserOwnership(any(), eq(99)))
+                .thenThrow(new ResponseStatusException(HttpStatus.FORBIDDEN,
+                        "You can only access your own reservations."));
+
+        mockMvc.perform(get("/api/reservations/user/99")
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + USER_TOKEN))
+                .andExpect(status().isForbidden())
+                .andExpect(jsonPath("$.message", equalTo("You can only access your own reservations.")));
+    }
+
+    // --- GET /api/reservations/event/{eventId} ---
+
+    @Test
+    void listByEventReturnsListForAdmin() throws Exception {
+        when(authorizationService.requireRole(any(), eq(AccountRole.ADMIN)))
+                .thenReturn(new AuthenticatedAccount(1, AccountRole.ADMIN, "Admin One"));
+        when(reservationService.listByEvent(10)).thenReturn(List.of(reservation(7, 2)));
+
+        mockMvc.perform(get("/api/reservations/event/10")
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + ADMIN_TOKEN))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$", hasSize(1)))
+                .andExpect(jsonPath("$[0].eventId").value(10));
+    }
+
+    @Test
+    void listByEventForbidsRegularUser() throws Exception {
+        when(authorizationService.requireRole(any(), eq(AccountRole.ADMIN)))
+                .thenThrow(new ResponseStatusException(HttpStatus.FORBIDDEN,
+                        "You do not have permission to access this resource."));
+
+        mockMvc.perform(get("/api/reservations/event/10")
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + USER_TOKEN))
+                .andExpect(status().isForbidden());
+    }
+
+    // --- POST /api/reservations ---
+
+    @Test
+    void createReservationReturns201() throws Exception {
+        Reservation created = reservation(8, 2);
+        when(authorizationService.requireUserOwnership(any(), eq(2)))
+                .thenReturn(new AuthenticatedAccount(2, AccountRole.USER, "User One"));
+        when(reservationService.createReservation(2, 10)).thenReturn(created);
+
+        mockMvc.perform(post("/api/reservations")
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + USER_TOKEN)
+                        .contentType(APPLICATION_JSON)
+                        .content("""
+                                {"userId": 2, "eventId": 10}
+                                """))
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.id").value(8))
+                .andExpect(jsonPath("$.status").value("CONFIRMED"));
+    }
+
+    @Test
+    void createReservationForbidsCreatingForOtherUser() throws Exception {
+        when(authorizationService.requireUserOwnership(any(), eq(99)))
+                .thenThrow(new ResponseStatusException(HttpStatus.FORBIDDEN,
+                        "You can only access your own reservations."));
+
+        mockMvc.perform(post("/api/reservations")
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + USER_TOKEN)
+                        .contentType(APPLICATION_JSON)
+                        .content("""
+                                {"userId": 99, "eventId": 10}
+                                """))
+                .andExpect(status().isForbidden());
+    }
+
+    @Test
+    void createReservationReturnsBadRequestWhenEventFullyBooked() throws Exception {
+        when(authorizationService.requireUserOwnership(any(), eq(2)))
+                .thenReturn(new AuthenticatedAccount(2, AccountRole.USER, "User One"));
+        when(reservationService.createReservation(2, 10))
+                .thenThrow(new ResponseStatusException(HttpStatus.BAD_REQUEST, "Event is fully booked."));
+
+        mockMvc.perform(post("/api/reservations")
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + USER_TOKEN)
+                        .contentType(APPLICATION_JSON)
+                        .content("""
+                                {"userId": 2, "eventId": 10}
+                                """))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.message", equalTo("Event is fully booked.")));
+    }
+
+    // --- PATCH /api/reservations/{id}/cancel ---
+
+    @Test
+    void cancelReservationReturnsUpdatedReservation() throws Exception {
+        Reservation existing = reservation(3, 2);
+        Reservation cancelled = new Reservation(3, 2, 10, ReservationStatus.CANCELLED,
+                LocalDateTime.parse("2026-01-01T10:00:00"), LocalDateTime.parse("2026-01-02T09:00:00"));
+        when(reservationService.getReservation(3)).thenReturn(existing);
+        when(authorizationService.requireUserOwnership(any(), eq(2)))
+                .thenReturn(new AuthenticatedAccount(2, AccountRole.USER, "User One"));
+        when(reservationService.cancelReservation(3)).thenReturn(cancelled);
+
+        mockMvc.perform(patch("/api/reservations/3/cancel")
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + USER_TOKEN))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.id").value(3))
+                .andExpect(jsonPath("$.status").value("CANCELLED"));
+    }
+
+    @Test
+    void cancelReservationForbidsOtherUsers() throws Exception {
+        Reservation existing = reservation(3, 99);
+        when(reservationService.getReservation(3)).thenReturn(existing);
+        when(authorizationService.requireUserOwnership(any(), eq(99)))
+                .thenThrow(new ResponseStatusException(HttpStatus.FORBIDDEN,
+                        "You can only access your own reservations."));
+
+        mockMvc.perform(patch("/api/reservations/3/cancel")
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + USER_TOKEN))
+                .andExpect(status().isForbidden())
+                .andExpect(jsonPath("$.message", equalTo("You can only access your own reservations.")));
+    }
+
+    @Test
+    void cancelReservationReturnsNotFoundWhenMissing() throws Exception {
+        when(reservationService.getReservation(404))
+                .thenThrow(new ResponseStatusException(HttpStatus.NOT_FOUND, "Reservation not found."));
+
+        mockMvc.perform(patch("/api/reservations/404/cancel")
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + ADMIN_TOKEN))
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.message", equalTo("Reservation not found.")));
+    }
+}

--- a/src/backend/src/test/java/com/letsgettesty/backend/user/JdbcUserRepositoryTest.java
+++ b/src/backend/src/test/java/com/letsgettesty/backend/user/JdbcUserRepositoryTest.java
@@ -1,0 +1,65 @@
+package com.letsgettesty.backend.user;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.util.List;
+import java.util.Optional;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.jdbc.core.RowMapper;
+
+import com.letsgettesty.backend.model.User;
+
+class JdbcUserRepositoryTest {
+
+    private final JdbcTemplate jdbcTemplate = mock(JdbcTemplate.class);
+    private final JdbcUserRepository repository = new JdbcUserRepository(jdbcTemplate);
+
+    private User sampleUser() {
+        return new User(42, "Jane Doe", "hashed-password", "jane@example.com", null);
+    }
+
+    // --- findById ---
+
+    @Test
+    @SuppressWarnings("unchecked")
+    void findByIdReturnsUserWhenFound() {
+        when(jdbcTemplate.query(anyString(), any(RowMapper.class), eq(42))).thenReturn(List.of(sampleUser()));
+
+        Optional<User> result = repository.findById(42);
+
+        assertThat(result).isPresent();
+        assertThat(result.get().getId()).isEqualTo(42);
+        assertThat(result.get().getFullName()).isEqualTo("Jane Doe");
+        assertThat(result.get().getEmail()).isEqualTo("jane@example.com");
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    void findByIdReturnsEmptyOptionalWhenNotFound() {
+        when(jdbcTemplate.query(anyString(), any(RowMapper.class), eq(999))).thenReturn(List.of());
+
+        Optional<User> result = repository.findById(999);
+
+        assertThat(result).isEmpty();
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    void findByIdReturnsUserWithPhoneWhenEmailIsNull() {
+        User userWithPhone = new User(7, "Sam Smith", "hashed", null, "514-555-0200");
+        when(jdbcTemplate.query(anyString(), any(RowMapper.class), eq(7))).thenReturn(List.of(userWithPhone));
+
+        Optional<User> result = repository.findById(7);
+
+        assertThat(result).isPresent();
+        assertThat(result.get().getEmail()).isNull();
+        assertThat(result.get().getPhone()).isEqualTo("514-555-0200");
+    }
+}


### PR DESCRIPTION
## Summary

- Add unit tests for all 10 previously untested backend files: `JwtService`, `AuthorizationService`, `JwtAuthInterceptor`, `AuthExceptionHandler`, `ReservationController`, `JdbcAuthRepository`, `JdbcEventRepository`, `JdbcReservationRepository`, `JdbcUserRepository`, and `JdbcNotificationRepository`
- 80 new test cases across 10 new test files

## Changes

### New test files
| File | What is tested |
|------|----------------|
| `JwtServiceTest.java` | Token generation produces a valid 3-segment JWT, authenticate correctly decodes claims, and invalid/expired/tampered tokens are rejected with 401 |
| `AuthorizationServiceTest.java` | Correct account is returned when role matches, 401 when no account is on the request, 403 when role or user ID doesn't match |
| `JwtAuthInterceptorTest.java` | OPTIONS requests are allowed through, missing or malformed Authorization headers throw 401, valid tokens set the authenticated account attribute on the request |
| `AuthExceptionHandlerTest.java` | `ResponseStatusException` is mapped to the correct HTTP status and error body, with a fallback message when no reason is provided |
| `ReservationControllerTest.java` | All 6 endpoints enforce the correct role/ownership rules, return the right status codes (200, 201, 403, 404), and error responses are properly formatted |
| `JdbcAuthRepositoryTest.java` | Existence checks return correct booleans including null handling, contact-based lookups return the right accounts, and account creation works for both USER and ADMIN roles |
| `JdbcEventRepositoryTest.java` | Fetching all events, finding by ID (found and not found), inserting a new event, updating fields, and toggling the cancelled flag |
| `JdbcReservationRepositoryTest.java` | Fetching all, by ID, by user, and by event; inserting, cancelling, and checking for duplicate confirmed reservations |
| `JdbcUserRepositoryTest.java` | `findById` returns the correct user when found, empty when not found, and handles users with phone instead of email |
| `JdbcNotificationRepositoryTest.java` | Inserting a notification persists all fields correctly and restores the subject (not stored in DB) from the input object |

## Results
I won't add 10 screenshots of them passing, but they all pass lol

